### PR TITLE
Project port hotfixes copy

### DIFF
--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -132,8 +132,8 @@ msgstr "Your account has been created. We send you an activation email. Please c
 
 #, elixir-autogen, elixir-format
 msgid "activation.failed.body"
-msgstr "Your account activation link is invalid or it has expired. Enter your email address and click resend to receive a new account activation link."
+msgstr "Your account might already have been activated or the activation link is expired. Click 'Sign in' at the top right to try to sign in with your account information. If your account is not activated, enter your email address below to receive a new activation link."
 
 #, elixir-autogen, elixir-format
 msgid "activation.failed.title"
-msgstr "Activation failed"
+msgstr "Account activation"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -342,4 +342,4 @@ msgstr "Expected number of participants"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "settings.language.label"
-msgstr "Language used in this assignment"
+msgstr "Language setting for participants"

--- a/core/test/core_web/live/user/confirm_token_test.exs
+++ b/core/test/core_web/live/user/confirm_token_test.exs
@@ -34,7 +34,7 @@ defmodule CoreWeb.Live.User.ConfirmToken.Test do
       # The second time should not redirect
       {:ok, _view, html} = live(conn, Routes.live_path(conn, ConfirmToken, "abc"))
 
-      assert html =~ "Activation failed"
+      assert html =~ "Account activation"
     end
 
     test "an invalid token does not activate the account", %{conn: conn} do
@@ -47,7 +47,7 @@ defmodule CoreWeb.Live.User.ConfirmToken.Test do
     test "an invalid token shows resend form", %{conn: conn} do
       {:ok, _view, html} = live(conn, Routes.live_path(conn, ConfirmToken, "abc"))
 
-      assert html =~ "Activation failed"
+      assert html =~ "Account activation"
     end
 
     test "resend form validates the email field", %{conn: conn} do
@@ -58,7 +58,8 @@ defmodule CoreWeb.Live.User.ConfirmToken.Test do
         |> element("form")
         |> render_submit(%{user: %{email: "a b c d"}})
 
-      assert html =~ "Your account activation link is invalid or it has expired."
+      assert html =~
+               "Your account might already have been activated or the activation link is expired."
     end
 
     test "resend form fakes sending mail when user does not exist", %{conn: conn} do


### PR DESCRIPTION
Adjusted activation failed and language copy (only English version).