### PR TITLE
#705: Add queries for benchmark challenge and graphite submissions

### DIFF
--- a/core/lib/core/factories.ex
+++ b/core/lib/core/factories.ex
@@ -250,7 +250,7 @@ defmodule Core.Factories do
   end
 
   def build(:workflow) do
-    build(:workflow, %{})
+    build(:workflow, %{type: :many_optional})
   end
 
   def build(:workflow_item) do

--- a/core/systems/graphite/_public.ex
+++ b/core/systems/graphite/_public.ex
@@ -9,6 +9,8 @@ defmodule Systems.Graphite.Public do
 
   alias Frameworks.Signal
   alias Systems.Graphite
+  alias Systems.Assignment
+  alias Systems.Workflow
 
   # FIXME: should come from CMS
   @main_category "f1_score"
@@ -76,6 +78,13 @@ defmodule Systems.Graphite.Public do
     end)
     |> Signal.Public.multi_dispatch({:graphite_submission, :updated})
     |> Repo.transaction()
+  end
+
+  def list_submissions(%Assignment.Model{workflow: workflow}) do
+    Workflow.Public.list_tools(workflow, :submit)
+    |> Enum.map(& &1.id)
+    |> submission_query()
+    |> Repo.all()
   end
 
   defp parse_entry(line) do

--- a/core/systems/graphite/_queries.ex
+++ b/core/systems/graphite/_queries.ex
@@ -25,4 +25,11 @@ defmodule Systems.Graphite.Queries do
       ]
     ])
   end
+
+  def submission_query(tool_ids) when is_list(tool_ids) do
+    # TODO: add check for locked flag when implementing https://github.com/eyra/mono/issues/706
+    build(submission_query(), :submission, [
+      tool_id in ^tool_ids
+    ])
+  end
 end

--- a/core/systems/project/_public.ex
+++ b/core/systems/project/_public.ex
@@ -1,6 +1,7 @@
 defmodule Systems.Project.Public do
   import Ecto.Query, warn: false
   import CoreWeb.Gettext
+  import Systems.Project.Queries
 
   alias Core.Repo
   alias Core.Accounts.User
@@ -104,6 +105,12 @@ defmodule Systems.Project.Public do
       preload: ^preload
     )
     |> Repo.all()
+  end
+
+  def list_items(node, {:assignment, template}, preload \\ []) do
+    item_query_by_assignment(node, template)
+    |> Repo.all()
+    |> Repo.preload(preload)
   end
 
   def exists?(user, name) do

--- a/core/systems/project/_queries.ex
+++ b/core/systems/project/_queries.ex
@@ -1,0 +1,27 @@
+defmodule Systems.Project.Queries do
+  require Ecto.Query
+  require Frameworks.Utility.Query
+
+  import Ecto.Query, warn: false
+  import Frameworks.Utility.Query, only: [build: 3]
+
+  alias Systems.Project
+
+  def item_query() do
+    from(Project.ItemModel, as: :item)
+  end
+
+  def item_query(%Project.NodeModel{id: node_id}) do
+    build(item_query(), :item, [
+      node_id == ^node_id
+    ])
+  end
+
+  def item_query_by_assignment(%Project.NodeModel{} = node, template) when is_atom(template) do
+    build(item_query(node), :item,
+      assignment: [
+        special == ^template
+      ]
+    )
+  end
+end

--- a/core/systems/workflow/_public.ex
+++ b/core/systems/workflow/_public.ex
@@ -1,9 +1,11 @@
 defmodule Systems.Workflow.Public do
   import Ecto.Query, warn: false
+  import Systems.Workflow.Queries
+
   alias Ecto.Multi
   alias Core.Repo
-
   alias Core.Authorization
+
   alias Frameworks.Signal
 
   alias Systems.Workflow
@@ -94,6 +96,16 @@ defmodule Systems.Workflow.Public do
     end)
     |> Signal.Public.multi_dispatch({:workflow_item, :added})
     |> Repo.transaction()
+  end
+
+  def list_tools(%Workflow.Model{} = workflow, special) do
+    preload = Workflow.ItemModel.preload_graph(:down)
+
+    item_query(workflow, special)
+    |> Repo.all()
+    |> Repo.preload(preload)
+    |> Enum.map(& &1.tool_ref)
+    |> Enum.map(&Project.ToolRefModel.tool/1)
   end
 
   def item_count(%Workflow.Model{id: workflow_id}) do

--- a/core/systems/workflow/_queries.ex
+++ b/core/systems/workflow/_queries.ex
@@ -1,0 +1,22 @@
+defmodule Systems.Workflow.Queries do
+  require Ecto.Query
+  require Frameworks.Utility.Query
+
+  import Ecto.Query, warn: false
+  import Frameworks.Utility.Query, only: [build: 3]
+
+  alias Systems.Workflow
+
+  def item_query() do
+    from(Workflow.ItemModel, as: :item)
+  end
+
+  def item_query(%Workflow.Model{id: workflow_id}, special) when is_atom(special) do
+    build(item_query(), :item, [
+      workflow_id == ^workflow_id,
+      tool_ref: [
+        special == ^special
+      ]
+    ])
+  end
+end

--- a/core/test/systems/graphite/factories.ex
+++ b/core/test/systems/graphite/factories.ex
@@ -1,0 +1,42 @@
+defmodule Systems.Graphite.Factories do
+  alias Core.Factories
+  alias Systems.Graphite
+  alias Systems.Workflow
+  alias Systems.Assignment
+
+  def create_tool() do
+    Factories.insert!(:graphite_tool, %{})
+  end
+
+  def create_challenge() do
+    Factories.insert!(:assignment, %{special: :benchmark_challenge})
+  end
+
+  def add_tool(%Assignment.Model{workflow: workflow}) do
+    tool = Factories.insert!(:graphite_tool)
+    tool_ref = Workflow.Factories.create_tool_ref(tool, :submit)
+    Workflow.Factories.create_item(workflow, tool_ref, 0)
+
+    tool
+  end
+
+  def add_submission(%Graphite.ToolModel{} = tool) do
+    Factories.insert!(:graphite_submission, %{
+      tool: tool,
+      description: "description",
+      github_commit_url:
+        "https://github.com/org/repo/commit/4cf8a66bcbe349488fabc211e1bfb72007a9f14a"
+    })
+  end
+
+  def create_submission(tool, description \\ "Method X") do
+    submission_attr = %{
+      tool: tool,
+      description: description,
+      github_commit_url:
+        "https://github.com/eyra/mono/commit/9d10bd2907dda135ebe86511489570dbf8c067c0"
+    }
+
+    Factories.insert!(:graphite_submission, submission_attr)
+  end
+end

--- a/core/test/systems/project/_public_test.exs
+++ b/core/test/systems/project/_public_test.exs
@@ -1,0 +1,83 @@
+defmodule Systems.Project.PublicTest do
+  use Core.DataCase
+
+  alias Systems.Project
+
+  describe "list_items/2" do
+    test "one matching item" do
+      item =
+        Core.Factories.build(:assignment, %{special: :benchmark_challenge})
+        |> Project.Factories.build_item()
+
+      %{root: %{id: node_id, items: [item]} = node} =
+        Project.Factories.build_node(items: [item])
+        |> Project.Factories.build_project()
+        |> Repo.insert!()
+
+      %{id: item_id, assignment: %{id: assignment_id}} = item
+
+      assert [
+               %Systems.Project.ItemModel{
+                 id: ^item_id,
+                 node_id: ^node_id,
+                 tool_ref_id: nil,
+                 assignment_id: ^assignment_id
+               }
+             ] = Project.Public.list_items(node, {:assignment, :benchmark_challenge})
+    end
+
+    test "multiple matching items" do
+      item1 =
+        Core.Factories.build(:assignment, %{special: :benchmark_challenge})
+        |> Project.Factories.build_item()
+
+      item2 =
+        Core.Factories.build(:assignment, %{special: :data_donation})
+        |> Project.Factories.build_item()
+
+      item3 =
+        Core.Factories.build(:assignment, %{special: :benchmark_challenge})
+        |> Project.Factories.build_item()
+
+      item4 =
+        Core.Factories.build(:assignment, %{special: :data_donation})
+        |> Project.Factories.build_item()
+
+      %{root: %{items: [%{id: item_1_id}, _, %{id: item_3_id}, _]} = node} =
+        Project.Factories.build_node(items: [item1, item2, item3, item4])
+        |> Project.Factories.build_project()
+        |> Repo.insert!()
+
+      assert [
+               %Systems.Project.ItemModel{id: ^item_1_id},
+               %Systems.Project.ItemModel{id: ^item_3_id}
+             ] = Project.Public.list_items(node, {:assignment, :benchmark_challenge})
+    end
+
+    test "no matching items" do
+      item1 =
+        Core.Factories.build(:assignment, %{special: :data_donation})
+        |> Project.Factories.build_item()
+
+      item2 =
+        Core.Factories.build(:assignment, %{special: :data_donation})
+        |> Project.Factories.build_item()
+
+      %{root: node} =
+        Project.Factories.build_node(items: [item1, item2])
+        |> Project.Factories.build_project()
+        |> Repo.insert!()
+
+      assert [] = Project.Public.list_items(node, {:assignment, :benchmark_challenge})
+    end
+
+    test "no items" do
+      %{root: node} =
+        Project.Factories.build_node(items: [])
+        |> Project.Factories.build_project()
+        |> Repo.insert!()
+
+      assert [] = Project.Public.list_items(node, {:assignment, :benchmark_challenge})
+    end
+  end
+end

--- a/core/test/systems/workflow/_public_test.exs
+++ b/core/test/systems/workflow/_public_test.exs
@@ -6,9 +6,63 @@ defmodule Systems.Workflow.PublicTest do
   alias Systems.Workflow
   alias Systems.Workflow.Factories
 
+  describe "list_tools/2 " do
+    test "no matching tool" do
+      workflow = Factories.create_workflow(:many_optional)
+
+      graphite_tool = Core.Factories.build(:graphite_tool)
+      tool_ref = Factories.create_tool_ref(graphite_tool, :submit)
+      Factories.create_item(workflow, tool_ref, 0)
+
+      assert [] = Workflow.Public.list_tools(workflow, :fake_special)
+    end
+
+    test "one matching tool" do
+      workflow = Factories.create_workflow(:many_optional)
+
+      graphite_tool = Core.Factories.build(:graphite_tool)
+      tool_ref = Factories.create_tool_ref(graphite_tool, :submit)
+      Factories.create_item(workflow, tool_ref, 0)
+
+      assert [
+               %Systems.Graphite.ToolModel{}
+             ] = Workflow.Public.list_tools(workflow, :submit)
+    end
+
+    test "multiple matching tool" do
+      workflow = Factories.create_workflow(:many_optional)
+
+      tool1 = Core.Factories.build(:graphite_tool)
+      tool_ref1 = Factories.create_tool_ref(tool1, :submit)
+      Factories.create_item(workflow, tool_ref1, 0)
+
+      tool2 = Core.Factories.build(:document_tool)
+      tool_ref2 = Factories.create_tool_ref(tool2, :request_manual)
+      Factories.create_item(workflow, tool_ref2, 1)
+
+      tool3 = Core.Factories.build(:graphite_tool)
+      tool_ref3 = Factories.create_tool_ref(tool3, :submit)
+      Factories.create_item(workflow, tool_ref3, 2)
+
+      tool4 = Core.Factories.build(:document_tool)
+      tool_ref4 = Factories.create_tool_ref(tool4, :download_manual)
+      Factories.create_item(workflow, tool_ref4, 3)
+
+      assert [
+               %Systems.Graphite.ToolModel{},
+               %Systems.Graphite.ToolModel{}
+             ] = Workflow.Public.list_tools(workflow, :submit)
+    end
+
+    test "no tools" do
+      workflow = Factories.create_workflow(:many_optional)
+      assert [] = Workflow.Public.list_tools(workflow, :submit)
+    end
+  end
+
   test "rearrange/2 move last to first succeed" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = item_a = Factories.create_item(workflow, tool_ref, 0)
@@ -42,7 +96,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "rearrange/2 move first to last succeed" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = item_a = Factories.create_item(workflow, tool_ref, 0)
@@ -76,7 +130,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 move first to last succeed" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = item_a = Factories.create_item(workflow, tool_ref, 0)
@@ -130,7 +184,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 move last to second succeed" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = Factories.create_item(workflow, tool_ref, 0)
@@ -184,7 +238,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 move to same position succeeded" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = Factories.create_item(workflow, tool_ref, 0)
@@ -218,7 +272,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 out of upper bounds failure" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     Factories.create_item(workflow, tool_ref, 0)
@@ -232,7 +286,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 out of lower bounds failure" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     Factories.create_item(workflow, tool_ref, 0)
@@ -246,7 +300,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 position out of sync failure" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     Factories.create_item(workflow, tool_ref, 0)
@@ -264,7 +318,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "update_position/2 item deleted underwater success" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     Factories.create_item(workflow, tool_ref, 0)
@@ -282,7 +336,7 @@ defmodule Systems.Workflow.PublicTest do
 
   test "delete/1 succeed" do
     tool = Factories.create_tool()
-    tool_ref = Factories.create_tool_ref(tool)
+    tool_ref = Factories.create_tool_ref(tool, :request_manual)
     workflow = Factories.create_workflow(:many_optional)
 
     %{id: id_a} = Factories.create_item(workflow, tool_ref, 0)

--- a/core/test/systems/workflow/factories.ex
+++ b/core/test/systems/workflow/factories.ex
@@ -1,6 +1,7 @@
 defmodule Systems.Workflow.Factories do
   alias Core.Factories
   alias Systems.Document
+  alias Systems.Graphite
 
   def create_tool() do
     Factories.insert!(:document_tool, %{
@@ -8,9 +9,17 @@ defmodule Systems.Workflow.Factories do
     })
   end
 
-  def create_tool_ref(%Document.ToolModel{} = tool) do
+  def create_tool_ref(%Document.ToolModel{} = tool, special) do
     Factories.insert!(:tool_ref, %{
+      special: special,
       document_tool: tool
+    })
+  end
+
+  def create_tool_ref(%Graphite.ToolModel{} = tool, special) do
+    Factories.insert!(:tool_ref, %{
+      special: special,
+      graphite_tool: tool
     })
   end
 


### PR DESCRIPTION
Implemented 3 main functions:

### **1. Systems.Project.Public.list_items/2**
Given a Project.NodeModel, returns the list items of certain type. Can be used to get items that refer to Assignment.Model{} with special == :benchmark_challenge. This is needed when to render form to select the Benchmark Challange assignment that needs to be connected to a Leaderboard. Example call:

```
benchmark_challenge_assignments = 
   project_node
   |> Systems.Project.Public.list_items({:assignment, :benchmark_challenge})
   |> Enum.map(& &1.assignment)
```

### **2. Systems.Workflow.Public.list_tools/2**
Given a Workflow.Model{}, returns the tools with a specific special in tool_ref. Example call:

```
%{workflow: workflow} = benchmark_challenge_assignment
graphite_tools = Systems.Workflow.Public.list_tools(workflow, :submit)
```

### 3. Systems.Graphite.Public.list_submissions/1
Given a list of Graphite.ToolModel{} ids, returns all the submissions

```
graphite_tools
|> Enum.map(& &1.id)
|>  Systems.Graphite.Public.list_submissions()
```

