### PR TITLE
Jan/benchmark config

### DIFF
--- a/core/frameworks/pixel/components/form.ex
+++ b/core/frameworks/pixel/components/form.ex
@@ -244,6 +244,38 @@ defmodule Frameworks.Pixel.Form do
 
   attr(:form, :any, required: true)
   attr(:field, :atom, required: true)
+  attr(:label_text, :string, default: nil)
+  attr(:label_color, :string, default: "text-grey1")
+  attr(:background, :atom, default: :light)
+  attr(:placeholder, :string, default: "")
+  attr(:reserve_error_space, :boolean, default: true)
+  attr(:debounce, :string, default: "1000")
+  attr(:maxlength, :string, default: "1000")
+  attr(:value, :string, default: "")
+
+  # FIXME: discuss how to make this neater. Now I just force the display of the
+  # provided value
+  # Used for working with providing a list of values in one text field in a form.
+  def list_input(assigns) do
+    ~H"""
+    <.input
+      form={@form}
+      field={@field}
+      label_text={@label_text}
+      label_color={@label_color}
+      background={@background}
+      placeholder={@placeholder}
+      reserve_error_space={@reserve_error_space}
+      debounce={@debounce}
+      maxlength={@maxlength}
+      type="text"
+      value={@value}
+    />
+    """
+  end
+
+  attr(:form, :any, required: true)
+  attr(:field, :atom, required: true)
   attr(:placeholder, :string, default: "")
   attr(:label_text, :string)
   attr(:label_color, :string, default: "text-grey1")

--- a/core/lib/core/authorization.ex
+++ b/core/lib/core/authorization.ex
@@ -58,6 +58,7 @@ defmodule Core.Authorization do
   grant_access(Systems.Graphite.ContentPage, [:researcher, :owner])
   grant_access(Systems.Graphite.ToolPage, [:owner])
   grant_access(Systems.Graphite.LeaderboardPage, [:visitor, :member])
+  grant_access(Systems.Graphite.LeaderboardContentPage, [:researcher, :owner])
   grant_access(Systems.Feldspar.AppPage, [:visitor, :member])
 
   grant_access(CoreWeb.User.Signin, [:visitor])

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
@@ -421,3 +421,27 @@ msgstr "Prepare method"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "project_item_templates.leaderboard"
 msgstr "Benchmark Leaderboard"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.concept"
+msgstr "Concept"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.offline"
+msgstr "Offline"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.online"
+msgstr "Online"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private"
+msgstr "Private"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private_with_date"
+msgstr "Private with date"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.public"
+msgstr "Public"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-graphite.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-graphite.po
@@ -167,4 +167,24 @@ msgstr "Update"
 
 #, elixir-autogen, elixir-format
 msgid "submit.failed.message"
-msgstr ""
+msgstr "Failed"
+
+#, elixir-autogen, elixir-format
+msgid "close.button"
+msgstr "Close"
+
+#, elixir-autogen, elixir-format
+msgid "open.button"
+msgstr "Open"
+
+#, elixir-autogen, elixir-format
+msgid "preview.button"
+msgstr "Preview"
+
+#, elixir-autogen, elixir-format
+msgid "publish.button"
+msgstr "Publish"
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "retract.button"
+msgstr "Retract"

--- a/core/priv/gettext/eyra-enums.pot
+++ b/core/priv/gettext/eyra-enums.pot
@@ -421,3 +421,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "project_item_templates.leaderboard"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.concept"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.offline"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.online"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private_with_date"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.public"
+msgstr ""

--- a/core/priv/gettext/eyra-graphite.pot
+++ b/core/priv/gettext/eyra-graphite.pot
@@ -168,3 +168,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "submit.failed.message"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "close.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "preview.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "publish.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "retract.button"
+msgstr ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-enums.po
@@ -421,3 +421,27 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "project_item_templates.leaderboard"
 msgstr "Benchmark Leaderboard"
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.concept"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.offline"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_status.online"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.private_with_date"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "leaderboard_visibility.public"
+msgstr ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-graphite.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-graphite.po
@@ -168,3 +168,23 @@ msgstr "Dien methode in"
 #, elixir-autogen, elixir-format
 msgid "submit.failed.message"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "close.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "preview.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "publish.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "retract.button"
+msgstr "Github voorbeeld repository"

--- a/core/priv/repo/migrations/20240404141441_add_metric_to_scores.exs
+++ b/core/priv/repo/migrations/20240404141441_add_metric_to_scores.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.AddMetricToScores do
+  use Ecto.Migration
+
+  def up do
+    alter table(:graphite_scores) do
+      add(:metric, :string)
+    end
+  end
+
+  def down do
+    alter table(:graphite_scores) do
+      remove(:metric)
+    end
+  end
+end

--- a/core/systems/graphite/_presenter.ex
+++ b/core/systems/graphite/_presenter.ex
@@ -10,5 +10,10 @@ defmodule Systems.Graphite.Presenter do
     builder(page).view_model(tool, assigns)
   end
 
+  def view_model(page, %Graphite.LeaderboardModel{} = tool, assigns) do
+    builder(page).view_model(tool, assigns)
+  end
+
   defp builder(Graphite.ToolPage), do: Graphite.ToolPageBuilder
+  defp builder(Graphite.LeaderboardContentPage), do: Graphite.LeaderboardContentBuilder
 end

--- a/core/systems/graphite/_private.ex
+++ b/core/systems/graphite/_private.ex
@@ -1,0 +1,11 @@
+defmodule Systems.Graphite.Private do
+  use CoreWeb, :verified_routes
+
+  alias Systems.{
+    Graphite
+  }
+
+  def get_preview_url(%Graphite.LeaderboardModel{id: id}) do
+    ~p"/graphite/leaderboard/#{id}"
+  end
+end

--- a/core/systems/graphite/_public.ex
+++ b/core/systems/graphite/_public.ex
@@ -79,6 +79,14 @@ defmodule Systems.Graphite.Public do
     |> Repo.transaction()
   end
 
+  def update_leaderboard(leaderboard, attrs) do
+    Multi.new()
+    |> Multi.update(:graphite_leaderboard, fn _ ->
+      Graphite.LeaderboardModel.changeset(leaderboard, attrs)
+    end)
+    |> Repo.transaction()
+  end
+
   def update_submission(submission, attrs) do
     Multi.new()
     |> Multi.update(:graphite_submission, fn _ ->

--- a/core/systems/graphite/_public.ex
+++ b/core/systems/graphite/_public.ex
@@ -148,7 +148,7 @@ defmodule Systems.Graphite.Public do
     |> Repo.transaction()
   end
 
-  defp create_scores(line, leaderboard, dt) do
+  defp create_scores(line, leaderboard, datetime) do
     leaderboard.metrics
     |> Enum.map(fn metric ->
       %{
@@ -156,14 +156,14 @@ defmodule Systems.Graphite.Public do
         score: String.to_float(line[metric]),
         leaderboard_id: leaderboard.id,
         submission_id: String.to_integer(line["submission"]),
-        inserted_at: dt,
-        updated_at: dt
+        inserted_at: datetime,
+        updated_at: datetime
       }
     end)
   end
 
-  defp update_leaderboard_generation_date(multi, leaderboard, dt) do
-    changeset = Graphite.LeaderboardModel.changeset(leaderboard, %{generation_date: dt})
+  defp update_leaderboard_generation_date(multi, leaderboard, datetime) do
+    changeset = Graphite.LeaderboardModel.changeset(leaderboard, %{generation_date: datetime})
     Multi.update(multi, :leaderboard_generation_date, changeset)
   end
 

--- a/core/systems/graphite/_routes.ex
+++ b/core/systems/graphite/_routes.ex
@@ -4,6 +4,8 @@ defmodule Systems.Graphite.Routes do
       scope "/graphite", Systems.Graphite do
         pipe_through([:browser, :require_authenticated_user])
 
+        live("/leaderboard/:id/content", LeaderboardContentPage)
+
         live("/:id/content", ContentPage)
         live("/:id/:spot", ToolPage)
 

--- a/core/systems/graphite/leaderboard_content_builder.ex
+++ b/core/systems/graphite/leaderboard_content_builder.ex
@@ -17,8 +17,7 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
       title: name,
       tabs: tabs,
       actions: actions(leaderboard, action_map),
-      show_errors: false,
-      default_tab: :settings
+      show_errors: false
     }
   end
 

--- a/core/systems/graphite/leaderboard_content_builder.ex
+++ b/core/systems/graphite/leaderboard_content_builder.ex
@@ -1,0 +1,201 @@
+defmodule Systems.Graphite.LeaderboardContentBuilder do
+  use CoreWeb, :verified_routes
+
+  import CoreWeb.Gettext
+
+  alias Systems.{
+    Graphite
+  }
+
+  def view_model(%{id: id, name: name} = leaderboard, assigns) do
+    action_map = action_map(leaderboard, assigns)
+
+    tabs = create_tabs(leaderboard, false, assigns)
+
+    %{
+      id: id,
+      title: name,
+      tabs: tabs,
+      actions: actions(leaderboard, action_map),
+      show_errors: false,
+      default_tab: :settings
+    }
+  end
+
+  defp actions(%{status: :concept}, %{preview: preview, publish: publish}) do
+    [preview: preview, publish: publish]
+  end
+
+  defp actions(%{status: :offline}, %{publish: publish, close: close}),
+    do: [publish: publish, close: close]
+
+  defp actions(%{status: :online}, %{retract: retract}), do: [retract: retract]
+
+  defp action_map(leaderboard, %{current_user: %{id: _user_id}}) do
+    preview_url = Graphite.Private.get_preview_url(leaderboard)
+
+    preview_action = %{type: :http_get, to: preview_url, target: "_blank"}
+    publish_action = %{type: :send, event: "action_click", item: :publish}
+    retract_action = %{type: :send, event: "action_click", item: :retract}
+    close_action = %{type: :send, event: "action_click", item: :close}
+    open_action = %{type: :send, event: "action_click", item: :open}
+
+    %{
+      preview: %{
+        label: %{
+          action: preview_action,
+          face: %{
+            type: :primary,
+            label: dgettext("eyra-assignment", "preview.button"),
+            bg_color: "bg-primary"
+          }
+        },
+        icon: %{
+          action: preview_action,
+          face: %{type: :icon, icon: :preview, alt: dgettext("eyra-assignment", "preview.button")}
+        }
+      },
+      publish: %{
+        label: %{
+          action: publish_action,
+          face: %{
+            type: :primary,
+            label: dgettext("eyra-assignment", "publish.button"),
+            bg_color: "bg-success"
+          }
+        },
+        icon: %{
+          action: publish_action,
+          face: %{type: :icon, icon: :publish, alt: dgettext("eyra-assignment", "preview.button")}
+        },
+        handle_click: &handle_publish/1
+      },
+      retract: %{
+        label: %{
+          action: retract_action,
+          face: %{
+            type: :secondary,
+            label: dgettext("eyra-assignment", "retract.button"),
+            text_color: "text-error",
+            border_color: "border-error"
+          }
+        },
+        icon: %{
+          action: retract_action,
+          face: %{
+            type: :icon,
+            icon: :retract,
+            alt: dgettext("eyra-benchmark", "assignment.button")
+          }
+        },
+        handle_click: &handle_retract/1
+      },
+      close: %{
+        label: %{
+          action: close_action,
+          face: %{
+            type: :primary,
+            label: dgettext("eyra-assignment", "close.button")
+          }
+        },
+        icon: %{
+          action: close_action,
+          face: %{type: :icon, icon: :close, alt: dgettext("eyra-assignment", "close.button")}
+        },
+        handle_click: &handle_close/1
+      },
+      open: %{
+        label: %{
+          action: open_action,
+          face: %{
+            type: :primary,
+            label: dgettext("eyra-assignment", "open.button")
+          }
+        },
+        icon: %{
+          action: open_action,
+          face: %{type: :icon, icon: :open, alt: dgettext("eyra-assignment", "open.button")}
+        },
+        handle_click: &handle_open/1
+      }
+    }
+  end
+
+  defp create_tabs(leaderboard, show_errors, assigns) do
+    get_tab_keys()
+    |> Enum.map(&create_tab(&1, leaderboard, show_errors, assigns))
+  end
+
+  defp get_tab_keys() do
+    [:settings, :upload]
+  end
+
+  defp create_tab(:settings, leaderboard, show_errors, assigns) do
+    %{fabric: fabric, uri_origin: uri_origin, viewport: viewport, breakpoint: breakpoint} =
+      assigns
+
+    child =
+      Fabric.prepare_child(fabric, :settings_form, Graphite.LeaderboardSettingsView, %{
+        entity: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      })
+
+    %{
+      id: "settings_form",
+      ready: false,
+      show_errors: show_errors,
+      title: "Settings",
+      forward_title: "Change settings",
+      backward_title: "Change settings",
+      type: :fullpage,
+      child: child
+    }
+  end
+
+  defp create_tab(:upload, leaderboard, show_errors, assigns) do
+    %{fabric: fabric, uri_origin: uri_origin, viewport: viewport, breakpoint: breakpoint} =
+      assigns
+
+    child =
+      Fabric.prepare_child(fabric, :settings_form, Graphite.LeaderboardUploadView, %{
+        entity: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      })
+
+    %{
+      id: "upload_form",
+      ready: false,
+      show_errors: show_errors,
+      title: "Upload results",
+      forward_title: "Upload results",
+      backward_title: "Upload results",
+      type: :fullpage,
+      child: child
+    }
+  end
+
+  defp handle_publish(socket) do
+    socket |> set_status(:online)
+  end
+
+  defp handle_retract(socket) do
+    socket |> set_status(:offline)
+  end
+
+  defp handle_close(socket) do
+    socket |> set_status(:idle)
+  end
+
+  defp handle_open(socket) do
+    socket |> set_status(:concept)
+  end
+
+  defp set_status(%{assigns: %{model: leaderboard}} = socket, status) do
+    {:ok, leaderboard} = Graphite.Public.update_leaderboard(leaderboard, %{status: status})
+    socket |> Phoenix.Component.assign(leaderboard: leaderboard)
+  end
+end

--- a/core/systems/graphite/leaderboard_content_builder.ex
+++ b/core/systems/graphite/leaderboard_content_builder.ex
@@ -45,13 +45,13 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
           action: preview_action,
           face: %{
             type: :primary,
-            label: dgettext("eyra-assignment", "preview.button"),
+            label: dgettext("eyra-graphite", "preview.button"),
             bg_color: "bg-primary"
           }
         },
         icon: %{
           action: preview_action,
-          face: %{type: :icon, icon: :preview, alt: dgettext("eyra-assignment", "preview.button")}
+          face: %{type: :icon, icon: :preview, alt: dgettext("eyra-graphite", "preview.button")}
         }
       },
       publish: %{
@@ -59,13 +59,13 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
           action: publish_action,
           face: %{
             type: :primary,
-            label: dgettext("eyra-assignment", "publish.button"),
+            label: dgettext("eyra-graphite", "publish.button"),
             bg_color: "bg-success"
           }
         },
         icon: %{
           action: publish_action,
-          face: %{type: :icon, icon: :publish, alt: dgettext("eyra-assignment", "preview.button")}
+          face: %{type: :icon, icon: :publish, alt: dgettext("eyra-graphite", "preview.button")}
         },
         handle_click: &handle_publish/1
       },
@@ -74,7 +74,7 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
           action: retract_action,
           face: %{
             type: :secondary,
-            label: dgettext("eyra-assignment", "retract.button"),
+            label: dgettext("eyra-graphite", "retract.button"),
             text_color: "text-error",
             border_color: "border-error"
           }
@@ -94,12 +94,12 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
           action: close_action,
           face: %{
             type: :primary,
-            label: dgettext("eyra-assignment", "close.button")
+            label: dgettext("eyra-graphite", "close.button")
           }
         },
         icon: %{
           action: close_action,
-          face: %{type: :icon, icon: :close, alt: dgettext("eyra-assignment", "close.button")}
+          face: %{type: :icon, icon: :close, alt: dgettext("eyra-graphite", "close.button")}
         },
         handle_click: &handle_close/1
       },
@@ -108,12 +108,12 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
           action: open_action,
           face: %{
             type: :primary,
-            label: dgettext("eyra-assignment", "open.button")
+            label: dgettext("eyra-graphite", "open.button")
           }
         },
         icon: %{
           action: open_action,
-          face: %{type: :icon, icon: :open, alt: dgettext("eyra-assignment", "open.button")}
+          face: %{type: :icon, icon: :open, alt: dgettext("eyra-graphite", "open.button")}
         },
         handle_click: &handle_open/1
       }
@@ -158,7 +158,7 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
       assigns
 
     child =
-      Fabric.prepare_child(fabric, :download_form, Graphite.LeaderboardDownloadView, %{
+      Fabric.prepare_child(fabric, :submissions_form, Graphite.LeaderboardDownloadView, %{
         entity: leaderboard,
         uri_origin: uri_origin,
         viewport: viewport,
@@ -182,7 +182,7 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
       assigns
 
     child =
-      Fabric.prepare_child(fabric, :settings_form, Graphite.LeaderboardUploadView, %{
+      Fabric.prepare_child(fabric, :scores_form, Graphite.LeaderboardUploadView, %{
         entity: leaderboard,
         uri_origin: uri_origin,
         viewport: viewport,

--- a/core/systems/graphite/leaderboard_content_builder.ex
+++ b/core/systems/graphite/leaderboard_content_builder.ex
@@ -126,7 +126,7 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
   end
 
   defp get_tab_keys() do
-    [:settings, :upload]
+    [:settings, :download, :upload]
   end
 
   defp create_tab(:settings, leaderboard, show_errors, assigns) do
@@ -148,6 +148,30 @@ defmodule Systems.Graphite.LeaderboardContentBuilder do
       title: "Settings",
       forward_title: "Change settings",
       backward_title: "Change settings",
+      type: :fullpage,
+      child: child
+    }
+  end
+
+  defp create_tab(:download, leaderboard, show_errors, assigns) do
+    %{fabric: fabric, uri_origin: uri_origin, viewport: viewport, breakpoint: breakpoint} =
+      assigns
+
+    child =
+      Fabric.prepare_child(fabric, :download_form, Graphite.LeaderboardDownloadView, %{
+        entity: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      })
+
+    %{
+      id: "download_form",
+      ready: false,
+      show_errors: show_errors,
+      title: "Download submissions",
+      forward_title: "Download submissions",
+      backward_title: "Download submissions",
       type: :fullpage,
       child: child
     }

--- a/core/systems/graphite/leaderboard_content_page.ex
+++ b/core/systems/graphite/leaderboard_content_page.ex
@@ -1,0 +1,41 @@
+defmodule Systems.Graphite.LeaderboardContentPage do
+  use CoreWeb, :live_view_fabric
+  use Fabric.LiveView, CoreWeb.Layouts
+  use Systems.Content.Page
+
+  alias Systems.{
+    Graphite
+  }
+
+  @impl true
+  def get_authorization_context(%{"id" => id}, _session, _socket) do
+    Graphite.Public.get_leaderboard!(id)
+  end
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    leaderboard =
+      Graphite.Public.get_leaderboard!(id, Graphite.LeaderboardModel.preload_graph(:down))
+
+    {:ok, socket |> initialize(id, leaderboard, "leaderboard_content/#{id}", "none")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.content_page
+      actions={@actions}
+      title={@vm.title}
+      show_errors={@vm.show_errors}
+      tabs={@vm.tabs}
+      menus={@menus}
+      initial_tab={@initial_tab}
+      tabbar_id={@tabbar_id}
+      tabbar_size={@tabbar_size}
+      breakpoint={@breakpoint}
+      popup={@popup}
+      dialog={@dialog}
+    />
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_content_page.ex
+++ b/core/systems/graphite/leaderboard_content_page.ex
@@ -17,7 +17,8 @@ defmodule Systems.Graphite.LeaderboardContentPage do
     leaderboard =
       Graphite.Public.get_leaderboard!(id, Graphite.LeaderboardModel.preload_graph(:down))
 
-    {:ok, socket |> initialize(id, leaderboard, "leaderboard_content/#{id}", "none")}
+    # Question: who should normally pass in the "default tab", which is now hard coded to "settings_form"
+    {:ok, socket |> initialize(id, leaderboard, "leaderboard_content/#{id}", "settings_form")}
   end
 
   @impl true

--- a/core/systems/graphite/leaderboard_download_form.ex
+++ b/core/systems/graphite/leaderboard_download_form.ex
@@ -26,15 +26,24 @@ defmodule Systems.Graphite.LeaderboardDownloadForm do
         leaderboard: leaderboard,
         uri_origin: uri_origin,
         viewport: viewport,
-        berakpoint: breakpoint,
-        placeholder: "Upload file",
-        select_button: "Select file",
-        replace_button: "Replace file",
-        csv_local_path: nil,
-        csv_remote_file: nil,
-        csv_lines: nil
+        berakpoint: breakpoint
       )
+      |> prepare_download_button("Download")
     }
+  end
+
+  defp prepare_download_button(socket, label) do
+    download_button = %{
+      action: %{type: :send, event: "download"},
+      face: %{type: :primary, label: label}
+    }
+
+    assign(socket, download_button: download_button)
+  end
+
+  @impl true
+  def handle_event("download", _params, socket) do
+    {:noreply, socket}
   end
 
   @impl true
@@ -47,6 +56,8 @@ defmodule Systems.Graphite.LeaderboardDownloadForm do
           <Text.title2>Download submission details</Text.title2>
           <Text.body_medium>Info on current submissions  here</Text.body_medium>
           <Text.body_medium>Also: download button</Text.body_medium>
+
+          <Button.dynamic {@download_button} />
         </div>
       </.form>
     </div>

--- a/core/systems/graphite/leaderboard_download_form.ex
+++ b/core/systems/graphite/leaderboard_download_form.ex
@@ -1,0 +1,55 @@
+defmodule Systems.Graphite.LeaderboardDownloadForm do
+  use CoreWeb.LiveForm, :fabric
+  use Fabric.LiveComponent
+
+  alias Frameworks.Pixel.Text
+
+  @impl true
+  def update(
+        %{
+          id: id,
+          leaderboard: leaderboard,
+          uri_origin: uri_origin,
+          viewport: viewport,
+          breakpoint: breakpoint
+        },
+        socket
+      ) do
+    columns = ["submission" | leaderboard.metrics]
+
+    {
+      :ok,
+      socket
+      |> assign(
+        id: id,
+        columns: columns,
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        berakpoint: breakpoint,
+        placeholder: "Upload file",
+        select_button: "Select file",
+        replace_button: "Replace file",
+        csv_local_path: nil,
+        csv_remote_file: nil,
+        csv_lines: nil
+      )
+    }
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.form id="select_file_form" for={%{}} phx-change="change" phx-target="" >
+        <div>
+          <.spacing value="L" />
+          <Text.title2>Download submission details</Text.title2>
+          <Text.body_medium>Info on current submissions  here</Text.body_medium>
+          <Text.body_medium>Also: download button</Text.body_medium>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_download_view.ex
+++ b/core/systems/graphite/leaderboard_download_view.ex
@@ -1,0 +1,72 @@
+defmodule Systems.Graphite.LeaderboardDownloadView do
+  use CoreWeb, :live_component_fabric
+  use Fabric.LiveComponent
+
+  alias Systems.{
+    Graphite
+  }
+
+  @impl true
+  def update(
+        %{
+          id: id,
+          entity: leaderboard,
+          uri_origin: uri_origin,
+          viewport: viewport,
+          breakpoint: breakpoint
+        },
+        socket
+      ) do
+    {
+      :ok,
+      socket
+      |> assign(
+        id: id,
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      )
+      |> compose_child(:upload)
+    }
+  end
+
+  @impl true
+  def compose(:upload, %{
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      }) do
+    %{
+      module: Graphite.LeaderboardDownloadForm,
+      params: %{
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint,
+        page_key: :upload,
+        opt_in?: false,
+        on_text: "download view on text",
+        off_text: "download view off text"
+      }
+    }
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <Area.content>
+        <.child name={:upload} fabric={@fabric} >
+          <:header>
+          </:header>
+          <:footer>
+            <.spacing value="L" />
+          </:footer>
+        </.child>
+      </Area.content>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_model.ex
+++ b/core/systems/graphite/leaderboard_model.ex
@@ -27,7 +27,8 @@ defmodule Systems.Graphite.LeaderboardModel do
   import Ecto.Changeset
 
   alias Systems.{
-    Graphite
+    Graphite,
+    Project
   }
 
   schema "graphite_leaderboards" do
@@ -43,6 +44,8 @@ defmodule Systems.Graphite.LeaderboardModel do
     has_many(:scores, Graphite.ScoreModel, foreign_key: :leaderboard_id)
     belongs_to(:tool, Graphite.ToolModel)
     belongs_to(:auth_node, Core.Authorization.Node)
+
+    has_one(:project_item, Project.ItemModel, foreign_key: :leaderboard_id)
 
     timestamps()
   end

--- a/core/systems/graphite/leaderboard_settings_form.ex
+++ b/core/systems/graphite/leaderboard_settings_form.ex
@@ -1,0 +1,92 @@
+defmodule Systems.Graphite.LeaderboardSettingsForm do
+  use CoreWeb.LiveForm, :fabric
+  use Fabric.LiveComponent
+
+  import Frameworks.Pixel.Form
+
+  alias Frameworks.Pixel.Text
+
+  alias Systems.{
+    Graphite
+  }
+
+  @visibility_options [
+    %{id: "public", value: "public", active: true},
+    %{id: "private", value: "private", active: false},
+    %{id: "private with date", value: "private with date", active: false}
+  ]
+
+  @allow_anonymous_options [
+    %{id: "false", value: false, active: true},
+    %{id: "true", value: true, active: false}
+  ]
+
+  @impl true
+  def update(%{id: id, leaderboard: leaderboard}, socket) do
+    changeset = Graphite.LeaderboardModel.changeset(leaderboard, %{})
+
+    {
+      :ok,
+      socket
+      |> assign(
+        id: id,
+        leaderboard: leaderboard,
+        changeset: changeset,
+        visibility_options: @visibility_options,
+        allow_anonymous_options: @allow_anonymous_options
+      )
+    }
+  end
+
+  @impl true
+  def handle_event("save", %{"leaderboard_model" => attrs}, socket) do
+    %{assigns: %{leaderboard: leaderboard}} = socket
+
+    attrs =
+      if attrs["metrics"] do
+        Map.put(attrs, "metrics", string_to_metrics(attrs["metrics"]))
+      else
+        attrs
+      end
+
+    {
+      :noreply,
+      socket
+      |> save(leaderboard, attrs)
+    }
+  end
+
+  defp save(socket, entity, attrs) do
+    changeset = Graphite.LeaderboardModel.changeset(entity, attrs)
+
+    socket
+    |> save(changeset)
+  end
+
+  defp metrics_to_string(nil), do: ""
+  defp metrics_to_string(metrics), do: Enum.join(metrics, ",")
+
+  defp string_to_metrics(metric_str) do
+    metric_str
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.form id={"#{@id}_settings"} :let={form} for={@changeset} phx-change="save" phx-target={@myself} >
+        <.spacing value="L" />
+        <Text.title2>Settings</Text.title2>
+        <.text_input form={form} field={:name} label_text="Name" />
+        <.text_input form={form} field={:version} label_text="Version" />
+        <.number_input form={form} field={:tool_id} label_text="Challenge ID" />
+        <.list_input form={form} field={:metrics} label_text="Metrics" value={metrics_to_string(@changeset.data.metrics)} />
+        <.radio_group form={form} field={:visibility} items={@visibility_options} label_text="Visibility" />
+        <.radio_group form={form} field={:allow_anonymous} items={@allow_anonymous_options} label_text="Allow anonymous" />
+      </.form>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_settings_view.ex
+++ b/core/systems/graphite/leaderboard_settings_view.ex
@@ -1,0 +1,64 @@
+defmodule Systems.Graphite.LeaderboardSettingsView do
+  use CoreWeb, :live_component_fabric
+  use Fabric.LiveComponent
+
+  alias Systems.{
+    Graphite
+  }
+
+  @impl true
+  def update(
+        %{
+          id: id,
+          entity: leaderboard,
+          uri_origin: uri_origin,
+          viewport: viewport,
+          breakpoint: breakpoint
+        },
+        socket
+      ) do
+    {
+      :ok,
+      socket
+      |> assign(
+        id: id,
+        entity: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      )
+      |> compose_child(:settings)
+    }
+  end
+
+  @impl true
+  def compose(:settings, %{entity: leaderboard}) do
+    %{
+      module: Graphite.LeaderboardSettingsForm,
+      params: %{
+        leaderboard: leaderboard,
+        page_key: :settings,
+        opt_in?: false,
+        on_text: "settings on text",
+        off_text: "settings off text"
+      }
+    }
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <Area.content>
+        <.child name={:settings} fabric={@fabric} >
+          <:header>
+          </:header>
+          <:footer>
+            <.spacing value="L" />
+          </:footer>
+        </.child>
+      </Area.content>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_upload_form.ex
+++ b/core/systems/graphite/leaderboard_upload_form.ex
@@ -1,0 +1,50 @@
+defmodule Systems.Graphite.LeaderboardUploadForm do
+  use CoreWeb.LiveForm, :fabric
+  use Fabric.LiveComponent
+
+  alias Frameworks.Pixel.Text
+
+  alias Systems.{
+    Graphite
+  }
+
+  @impl true
+  def update(%{id: id, leaderboard: leaderboard}, socket) do
+    {
+      :ok,
+      socket
+      |> assign(id: id, leaderboard: leaderboard)
+    }
+  end
+
+  @impl true
+  def handle_event("save", %{"leaderboard_model" => attrs}, socket) do
+    %{assigns: %{leaderboard: leaderboard}} = socket
+
+    {
+      :noreply,
+      socket
+      |> save(leaderboard, attrs)
+    }
+  end
+
+  defp save(socket, entity, attrs) do
+    # No longer needed, change to dealing with upload
+    changeset = Graphite.LeaderboardModel.changeset(entity, attrs)
+
+    socket
+    |> save(changeset)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.form id={"#{@id}_settings"} :let={_form} for={%{}} phx-change="save" phx-target={@myself} >
+        <.spacing value="L" />
+        <Text.title2>Upload results</Text.title2>
+      </.form>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_upload_form.ex
+++ b/core/systems/graphite/leaderboard_upload_form.ex
@@ -96,10 +96,9 @@ defmodule Systems.Graphite.LeaderboardUploadForm do
     <div>
       <.form id="select_file_form" for={%{}} phx-change="change" phx-target="" >
         <div>
-          <Area.content>
-            <Text.title2>Scores upload</Text.title2>
-            <Text.body_medium>Expecting the following columns to be present in the file: <%= Enum.join(@columns, ", ") %></Text.body_medium>
-          </Area.content>
+          <.spacing value="L" />
+          <Text.title2>Scores upload</Text.title2>
+          <Text.body_medium>Expecting the following columns to be present in the file: <%= Enum.join(@columns, ", ") %></Text.body_medium>
         </div>
         <div class="h-file-selector border-grey4 border-2 rounded pl-6 pr-6">
           <div class="flex flex-row items-center h-full">

--- a/core/systems/graphite/leaderboard_upload_form.ex
+++ b/core/systems/graphite/leaderboard_upload_form.ex
@@ -1,6 +1,7 @@
 defmodule Systems.Graphite.LeaderboardUploadForm do
   use CoreWeb.LiveForm, :fabric
   use Fabric.LiveComponent
+  use CoreWeb.FileUploader, accept: ~w(.csv)
 
   alias Frameworks.Pixel.Text
 
@@ -9,41 +10,127 @@ defmodule Systems.Graphite.LeaderboardUploadForm do
   }
 
   @impl true
-  def update(%{id: id, leaderboard: leaderboard}, socket) do
+  def update(
+        %{
+          id: id,
+          leaderboard: leaderboard,
+          uri_origin: uri_origin,
+          viewport: viewport,
+          breakpoint: breakpoint
+        },
+        socket
+      ) do
+    columns = ["submission" | leaderboard.metrics]
+
     {
       :ok,
       socket
-      |> assign(id: id, leaderboard: leaderboard)
+      |> assign(
+        id: id,
+        columns: columns,
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        berakpoint: breakpoint,
+        placeholder: "Upload file",
+        select_button: "Select file",
+        replace_button: "Replace file",
+        csv_local_path: nil,
+        csv_remote_file: nil,
+        csv_lines: nil
+      )
+      |> init_file_uploader(:csv)
+      |> prepare_process_button("processign")
     }
+  end
+
+  defp prepare_process_button(socket, label) do
+    process_button = %{
+      action: %{type: :send, event: "process"},
+      face: %{type: :primary, label: label}
+    }
+
+    assign(socket, process_button: process_button)
   end
 
   @impl true
-  def handle_event("save", %{"leaderboard_model" => attrs}, socket) do
-    %{assigns: %{leaderboard: leaderboard}} = socket
-
-    {
-      :noreply,
-      socket
-      |> save(leaderboard, attrs)
-    }
+  def process_file(socket, {path, _url, original_file_name}) do
+    socket
+    |> assign(csv_local_path: path, csv_remote_file: original_file_name)
   end
 
-  defp save(socket, entity, attrs) do
-    # No longer needed, change to dealing with upload
-    changeset = Graphite.LeaderboardModel.changeset(entity, attrs)
+  @impl true
+  def handle_event("process", _params, %{assigns: %{csv_local_path: csv_local_path}} = socket) do
+    %{assigns: %{entity: leaderboard}} = socket
 
-    socket
-    |> save(changeset)
+    lines =
+      csv_local_path
+      |> File.stream!()
+      |> CSV.decode(headers: true)
+
+    lines_ok =
+      lines
+      |> Stream.filter(&filter_ok/1)
+      |> Stream.map(fn {:ok, line} -> line end)
+      |> Enum.filter(fn line -> check_line(line, leaderboard) end)
+
+    Graphite.Public.import_csv_lines(socket.assigns.entity, lines_ok)
+    {:noreply, assign(socket, csv_lines: lines_ok)}
+  end
+
+  defp filter_ok({:ok, _line}), do: true
+  defp filter_ok({:error, _line}), do: false
+
+  defp check_line(line, metrics) do
+    line
+    |> contains_all_metrics?(metrics)
+  end
+
+  defp contains_all_metrics?(line, metrics) do
+    Enum.all?(metrics, fn metric -> Map.has_key?(line, metric) end)
   end
 
   @impl true
   def render(assigns) do
     ~H"""
     <div>
-      <.form id={"#{@id}_settings"} :let={_form} for={%{}} phx-change="save" phx-target={@myself} >
-        <.spacing value="L" />
-        <Text.title2>Upload results</Text.title2>
+      <.form id="select_file_form" for={%{}} phx-change="change" phx-target="" >
+        <div>
+          <Area.content>
+            <Text.title2>Scores upload</Text.title2>
+            <Text.body_medium>Expecting the following columns to be present in the file: <%= Enum.join(@columns, ", ") %></Text.body_medium>
+          </Area.content>
+        </div>
+        <div class="h-file-selector border-grey4 border-2 rounded pl-6 pr-6">
+          <div class="flex flex-row items-center h-full">
+            <div class="flex-grow">
+              <%= if @csv_remote_file do %>
+                <Text.body_large color="text-grey1"><%= @csv_remote_file %></Text.body_large>
+              <% else %>
+                <Text.body_large color="text-grey2"><%= @placeholder %></Text.body_large>
+              <% end %>
+            </div>
+            <%= if @csv_remote_file do %>
+              <Button.primary_label label={@replace_button} bg_color="bg-tertiary" text_color="text-grey1" field={@uploads.csv.ref} />
+            <% else %>
+              <Button.primary_label label={@select_button} bg_color="bg-tertiary" text_color="text-grey1" field={@uploads.csv.ref} />
+            <% end %>
+          </div>
+          <div class="hidden">
+            <.live_file_input upload={@uploads.csv} />
+          </div>
+        </div>
       </.form>
+      <.spacing value="M" />
+      <%= if @csv_local_path do %>
+          <.wrap>
+            <Button.dynamic {@process_button} />
+          </.wrap>
+      <% end %>
+      <.spacing value="M" />
+      <%= if @csv_lines do %>
+        Uploaded <%= length(@csv_lines) %> scores.
+      <% end %>
     </div>
     """
   end

--- a/core/systems/graphite/leaderboard_upload_form.ex
+++ b/core/systems/graphite/leaderboard_upload_form.ex
@@ -40,7 +40,7 @@ defmodule Systems.Graphite.LeaderboardUploadForm do
         csv_lines: nil
       )
       |> init_file_uploader(:csv)
-      |> prepare_process_button("processign")
+      |> prepare_process_button("processing")
     }
   end
 

--- a/core/systems/graphite/leaderboard_upload_view.ex
+++ b/core/systems/graphite/leaderboard_upload_view.ex
@@ -1,0 +1,64 @@
+defmodule Systems.Graphite.LeaderboardUploadView do
+  use CoreWeb, :live_component_fabric
+  use Fabric.LiveComponent
+
+  alias Systems.{
+    Graphite
+  }
+
+  @impl true
+  def update(
+        %{
+          id: id,
+          entity: leaderboard,
+          uri_origin: uri_origin,
+          viewport: viewport,
+          breakpoint: breakpoint
+        },
+        socket
+      ) do
+    {
+      :ok,
+      socket
+      |> assign(
+        id: id,
+        entity: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      )
+      |> compose_child(:upload)
+    }
+  end
+
+  @impl true
+  def compose(:upload, %{entity: leaderboard}) do
+    %{
+      module: Graphite.LeaderboardUploadForm,
+      params: %{
+        leaderboard: leaderboard,
+        page_key: :upload,
+        opt_in?: false,
+        on_text: "upload view on text",
+        off_text: "upload view off text"
+      }
+    }
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <Area.content>
+        <.child name={:upload} fabric={@fabric} >
+          <:header>
+          </:header>
+          <:footer>
+            <.spacing value="L" />
+          </:footer>
+        </.child>
+      </Area.content>
+    </div>
+    """
+  end
+end

--- a/core/systems/graphite/leaderboard_upload_view.ex
+++ b/core/systems/graphite/leaderboard_upload_view.ex
@@ -22,7 +22,7 @@ defmodule Systems.Graphite.LeaderboardUploadView do
       socket
       |> assign(
         id: id,
-        entity: leaderboard,
+        leaderboard: leaderboard,
         uri_origin: uri_origin,
         viewport: viewport,
         breakpoint: breakpoint
@@ -32,11 +32,19 @@ defmodule Systems.Graphite.LeaderboardUploadView do
   end
 
   @impl true
-  def compose(:upload, %{entity: leaderboard}) do
+  def compose(:upload, %{
+        leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint
+      }) do
     %{
       module: Graphite.LeaderboardUploadForm,
       params: %{
         leaderboard: leaderboard,
+        uri_origin: uri_origin,
+        viewport: viewport,
+        breakpoint: breakpoint,
         page_key: :upload,
         opt_in?: false,
         on_text: "upload view on text",

--- a/core/systems/graphite/score_model.ex
+++ b/core/systems/graphite/score_model.ex
@@ -10,13 +10,14 @@ defmodule Systems.Graphite.ScoreModel do
 
   schema "graphite_scores" do
     field(:score, :float)
+    field(:metric, :string)
     belongs_to(:leaderboard, Graphite.LeaderboardModel)
     belongs_to(:submission, Graphite.SubmissionModel)
 
     timestamps()
   end
 
-  @fields ~w(score)a
+  @fields ~w(score metric)a
   @required_fields ~w()a
 
   def changeset(tool, params) do

--- a/core/systems/project/item_model.ex
+++ b/core/systems/project/item_model.ex
@@ -204,7 +204,7 @@ defmodule Systems.Project.ItemModel do
            %{
              id: id,
              name: name,
-             leaderboard: %{id: _leaderboard_id, status: status} = leaderboard
+             leaderboard: %{id: leaderboard_id, status: status} = leaderboard
            },
            {Project.NodePage, :item_card},
            _user
@@ -222,7 +222,7 @@ defmodule Systems.Project.ItemModel do
       %{
         type: :secondary,
         id: id,
-        path: ~p"/",
+        path: ~p"/graphite/leaderboard/#{leaderboard_id}/content",
         label: get_label(status),
         title: name,
         tags: get_card_tags(leaderboard),


### PR DESCRIPTION
Adds the basic tabs when dealing with a leaderboard.
Basic config is in place, and placeholders for downloading submissions and uploading scores.