### PR TITLE
730 add feature flag check around leaderboard button in workflow cms submit task

### DIFF
--- a/core/systems/graphite/tool_form.ex
+++ b/core/systems/graphite/tool_form.ex
@@ -70,6 +70,7 @@ defmodule Systems.Graphite.ToolForm do
 
   @impl true
   def handle_event("create_leaderboard", _payload, %{assigns: %{entity: entity}} = socket) do
+    require_feature(:leaderboard)
     Graphite.Assembly.create_leaderboard(entity)
     {:noreply, socket}
   end
@@ -94,8 +95,10 @@ defmodule Systems.Graphite.ToolForm do
     <div id={"#{@id}_timezone"} class="timezone" phx-hook="TimeZone">
       <.form id={"#{@id}_graphite_tool_form"} :let={form} for={@changeset} phx-change="change" phx-target="" >
         <.datetime_input form={form} field={:deadline_string} label_text={dgettext("eyra-graphite", "deadline.label", timezone: @timezone)}/>
-        <.spacing value="XS" />
-        <Button.dynamic_bar buttons={[@leaderboard_button]} />
+        <%= if feature_enabled?(:leaderboard) do %>
+          <.spacing value="XS" />
+          <Button.dynamic_bar buttons={[@leaderboard_button]} />
+        <% end %>
         <.spacing value="M" />
       </.form>
     </div>

--- a/core/systems/graphite/tool_view.ex
+++ b/core/systems/graphite/tool_view.ex
@@ -179,7 +179,7 @@ defmodule Systems.Graphite.ToolView do
           <Text.title3><%= dgettext("eyra-graphite", "leaderboard.title") %></Text.title3>
           <.spacing value="M" />
 
-          <%= if @leaderboard_button do %>
+          <%= if feature_enabled?(:leaderboard) and @leaderboard_button do %>
             <Text.body><%= dgettext("eyra-graphite", "leaderboard.published.message") %></Text.body>
             <.spacing value="S" />
             <Button.dynamic_bar buttons={[@leaderboard_button]} />

--- a/core/systems/project/node_page_builder.ex
+++ b/core/systems/project/node_page_builder.ex
@@ -1,4 +1,6 @@
 defmodule Systems.Project.NodePageBuilder do
+  use Core.FeatureFlags
+
   alias Frameworks.Utility.ViewModelBuilder
 
   alias Systems.{
@@ -32,7 +34,14 @@ defmodule Systems.Project.NodePageBuilder do
 
   defp to_item_cards(%{items: items}, assigns) do
     items
+    |> Enum.filter(&item_feature_enabled?/1)
     |> Enum.sort_by(& &1.inserted_at, {:asc, NaiveDateTime})
     |> Enum.map(&ViewModelBuilder.view_model(&1, {Project.NodePage, :item_card}, assigns))
   end
+
+  defp item_feature_enabled?(%{leaderboard_id: leaderboard_id}) when not is_nil(leaderboard_id) do
+    feature_enabled?(:leaderboard)
+  end
+
+  defp item_feature_enabled?(_), do: true
 end


### PR DESCRIPTION
Feature flag applied on 3 locations:

1. Project item overview (Organizers)
Leaderboard items are not rendered

2. Workflow CMS Submit task (Organizers)
Leaderboard buttons (Create / Go to) are not rendered

3. Submit task view (Participants)
Leaderboard button (Go to) is not rendered
