### PR TITLE
Fix: Donations are not stored by store in builtin/local_fs.ex

### DIFF
--- a/core/systems/storage/builtin/local_fs.ex
+++ b/core/systems/storage/builtin/local_fs.ex
@@ -3,8 +3,7 @@ defmodule Systems.Storage.BuiltIn.LocalFS do
   use CoreWeb, :verified_routes
 
   @impl true
-  def store(folder, identifier, data) do
-    filename = Enum.join(identifier, "_") <> ".json"
+  def store(folder, filename, data) do
     folder_path = get_full_path(folder)
     File.mkdir(folder_path)
     file_path = Path.join(folder_path, filename)


### PR DESCRIPTION
# Problem

Noticed when running in docker container with "builtin" withouth AWS bucket configured donation were not stored in local fs.

The following error is thrown:

```
10:58:38.490 [error] ** (Protocol.UndefinedError) protocol Enumerable not implemented for "assignment=1_task=1_participant=preview_source=asd_key=1729241868162-tracking.json" of type BitString
    (elixir 1.14.0) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.14.0) lib/enum.ex:166: Enumerable.reduce/3
    (elixir 1.14.0) lib/enum.ex:4307: Enum.join/2
    (core 0.1.0) systems/storage/builtin/local_fs.ex:10: Systems.Storage.BuiltIn.LocalFS.store/3
    (core 0.1.0) systems/storage/delivery.ex:36: Systems.Storage.Delivery.deliver/4
    (core 0.1.0) systems/storage/delivery.ex:18: Systems.Storage.Delivery.perform/1
    (oban 2.13.6) lib/oban/queue/executor.ex:129: Oban.Queue.Executor.perform/1
    (oban 2.13.6) lib/oban/queue/executor.ex:74: Oban.Queue.Executor.call/1
```

# Fix

Tracked the problem down to:

```
core/systems/storage/builtin/local_fs.ex
```

`backend.ex` already creates the filename. So, changed the store function accordingly.
It now works as expected.