### PR TITLE
Add support for AppSignal revisions

### DIFF
--- a/core/config/runtime.exs
+++ b/core/config/runtime.exs
@@ -146,7 +146,7 @@ if config_env() == :prod do
       otp_app: :core,
       name: "Next",
       env: app_domain,
-      release: System.get_env("APPSIGNAL_REVISION"),
+      revision: System.get_env("APPSIGNAL_REVISION"),
       push_api_key: push_api_key,
       active: true
   end

--- a/core/config/runtime.exs
+++ b/core/config/runtime.exs
@@ -146,6 +146,7 @@ if config_env() == :prod do
       otp_app: :core,
       name: "Next",
       env: app_domain,
+      release: System.get_env("APPSIGNAL_REVISION"),
       push_api_key: push_api_key,
       active: true
   end


### PR DESCRIPTION
We want to be able to see which application version is deployed on an environment within AppSignal
- This can be signalled through the '[revision](https://docs.appsignal.com/application/markers/deploy-markers.html)' parameter using the AppSignal module
- This code adds this parameter, deployment workflow will also be changed to set this env var.
- A test build has been released on our development environment and works (See deploys)