### PR TITLE
builtin/local_fs.ex fix

### DIFF
--- a/core/systems/storage/builtin/local_fs.ex
+++ b/core/systems/storage/builtin/local_fs.ex
@@ -14,8 +14,25 @@ defmodule Systems.Storage.BuiltIn.LocalFS do
   @impl true
   def list_files(folder) do
     folder_path = get_full_path(folder)
+    File.mkdir(folder_path)
+    
     File.ls!(folder_path)
+    |> Enum.map(fn filename ->
+      file_path = Path.join(folder_path, filename)
+      {:ok, %File.Stat{mtime: mtime, size: size}} = File.stat(file_path)
+
+      datetime = mtime
+      |> NaiveDateTime.from_erl!()
+      |> DateTime.from_naive!("Etc/UTC")
+
+      %{
+        path: file_path,
+        size: size,
+        timestamp: datetime,
+      }
+    end)
   end
+
 
   @impl true
   def delete_files(folder) do


### PR DESCRIPTION
Context: running next with bundle self with builtin/local_fs

There were 2 issues with `core/systems/storage/builtin/local_fs.ex` causing a crash of the view. Preventing the user to further use the view. i.e. to click items in the overview tab.

Issues:
* `list_files` get called at in the code before the folder is created, the view crashes when that happens
* `list_files` does not return the correct format for `Systems.Storage.Html.files_table` resulting in a crash

Solutions:
* so line 17 is to ensure the folder exists.
* make sure list_files returns a list of objects with maps containing the keys: path, size and timestamp