### PR TITLE
Translate IdP transfer actions

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -406,3 +406,11 @@ msgstr "Wir haben festgestellt, dass Sie bereits ein Konto mit der E-Mail-Adress
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Anmeldung übertragen"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Übertragung bestätigen"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Ablehnen"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -407,3 +407,11 @@ msgstr "We detected you have an existing account with email address <strong>%{em
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Transfer authentication"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Confirm transfer"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Decline"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -406,3 +406,11 @@ msgstr "Hemos detectado que ya tiene una cuenta con la dirección de correo elec
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Transferir autenticación"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Confirmar transferencia"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Rechazar"

--- a/core/priv/gettext/eyra-account.pot
+++ b/core/priv/gettext/eyra-account.pot
@@ -405,3 +405,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -406,3 +406,11 @@ msgstr "Abbiamo rilevato che hai già un account con l'indirizzo email <strong>%
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Trasferisci autenticazione"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Conferma il trasferimento"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Rifiuta"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -415,3 +415,11 @@ msgstr "Aptikome, kad jau turite paskyrą su el. pašto adresu <strong>%{email}<
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Perkelti autentifikavimą"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Patvirtinti perkėlimą"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Atmesti"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -407,3 +407,11 @@ msgstr "We hebben vastgesteld dat u al een account hebt met e-mailadres <strong>
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Inlogmethode wijzigen"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Overdracht bevestigen"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Weigeren"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -415,3 +415,11 @@ msgstr "Am detectat că aveți deja un cont cu adresa de e-mail <strong>%{email}
 #, elixir-autogen, elixir-format
 msgid "idp.transfer.title"
 msgstr "Transferă autentificarea"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.confirm"
+msgstr "Confirmă transferul"
+
+#, elixir-autogen, elixir-format
+msgid "idp.transfer.decline"
+msgstr "Refuză"

--- a/core/systems/account/auth/identity_provider_transfer_page.ex
+++ b/core/systems/account/auth/identity_provider_transfer_page.ex
@@ -62,12 +62,12 @@ defmodule Systems.Account.Auth.IdentityProviderTransferPage do
               <Button.dynamic_bar buttons={[
                 %{
                   action: %{type: :http_post, to: ~p"/auth/#{@idp_key}/transfer/confirm"},
-                  face: %{type: :primary, label: "Confirm transfer"},
+                  face: %{type: :primary, label: dgettext("eyra-account", "idp.transfer.confirm")},
                   testid: "idp-transfer-confirm"
                 },
                 %{
                   action: %{type: :http_post, to: ~p"/auth/#{@idp_key}/transfer/decline"},
-                  face: %{type: :secondary, label: "Decline"},
+                  face: %{type: :secondary, label: dgettext("eyra-account", "idp.transfer.decline")},
                   testid: "idp-transfer-decline"
                 }
               ]} />

--- a/core/test/systems/account/_public_test.exs
+++ b/core/test/systems/account/_public_test.exs
@@ -1,5 +1,5 @@
 defmodule Systems.Account.PublicTest do
-  use Core.DataCase, async: true
+  use Core.DataCase
   import Frameworks.Signal.TestHelper
 
   alias Core.Factories

--- a/core/test/systems/account/auth_test.exs
+++ b/core/test/systems/account/auth_test.exs
@@ -1,5 +1,5 @@
 defmodule Systems.Account.AuthTest do
-  use Core.DataCase, async: true
+  use Core.DataCase
   import Frameworks.Signal.TestHelper
 
   alias Core.Factories


### PR DESCRIPTION
## Goal
Show the IdP-transfer confirmation and decline actions in the selected account locale rather than always in English.

## Changes
- Replace hardcoded transfer-action labels with account gettext keys.
- Add translations for English, Dutch, German, Spanish, Italian, Lithuanian, and Romanian.
- Serialize account tests that temporarily replace global signal handlers, preventing order-dependent full-suite failures.

## Verification
- `make test` — Core: 2,645 tests and 27 features; assets: 13 tests; banking_proxy: 19 tests.
- `mix test test/features/auth_identity_provider_transfer_test.exs` — 2 features passed.