### PR TITLE
Fix rejected participation routing

### DIFF
--- a/core/systems/assignment/_public.ex
+++ b/core/systems/assignment/_public.ex
@@ -529,7 +529,7 @@ defmodule Systems.Assignment.Public do
   defp ensure_fund_currency(fund), do: fund
 
   def participant_id(%Assignment.Model{crew: crew}, user) do
-    case Crew.Public.get_member_unsafe(crew, user) do
+    case Crew.Public.get_member_including_expired(crew, user) do
       %{public_id: public_id} -> {:ok, public_id}
       _ -> :error
     end
@@ -673,7 +673,7 @@ defmodule Systems.Assignment.Public do
 
   def reset_member(%{crew: crew} = assignment, user, opts \\ []) do
     # get member regardless expired state
-    if member = Crew.Public.get_member_unsafe(crew, user, [:crew]) do
+    if member = Crew.Public.get_member_including_expired(crew, user, [:crew]) do
       expire_at = expiration_timestamp(assignment)
       Crew.Public.reset_member!(member, expire_at, opts)
     else

--- a/core/systems/assignment/crew_page_builder.ex
+++ b/core/systems/assignment/crew_page_builder.ex
@@ -44,7 +44,7 @@ defmodule Systems.Assignment.CrewPageBuilder do
       view: current_view(assignment, assigns_with_context),
       info: assignment.info,
       crew: crew,
-      crew_member: Crew.Public.get_member_unsafe(crew, user),
+      crew_member: Crew.Public.get_member_including_expired(crew, user),
       user_state: user_state,
       footer: %{
         privacy_text: dgettext("eyra-ui", "privacy.link"),
@@ -259,7 +259,7 @@ defmodule Systems.Assignment.CrewPageBuilder do
 
   defp work_items(%{status: status, crew: crew} = assignment, %{current_user: user}) do
     if Assignment.Public.tester?(assignment, user) or status == :online do
-      member = Crew.Public.get_member(crew, user)
+      member = Crew.Public.get_member_including_expired(crew, user)
       work_items(assignment, member, user)
     else
       []

--- a/core/systems/crew/_public.ex
+++ b/core/systems/crew/_public.ex
@@ -259,8 +259,7 @@ defmodule Systems.Crew.Public do
     |> Repo.preload(preload)
   end
 
-  def get_member_unsafe(crew, user_ref, preload \\ []) do
-    # method is unsafe since it returns members regardless their expired status
+  def get_member_including_expired(crew, user_ref, preload \\ []) do
     member_query(crew, user_ref)
     |> Repo.one()
     |> Repo.preload(preload)

--- a/core/test/systems/assignment/crew_page_builder_test.exs
+++ b/core/test/systems/assignment/crew_page_builder_test.exs
@@ -72,6 +72,28 @@ defmodule Systems.Assignment.CrewPageBuilderTest do
       assert view.implementation == Assignment.FinishedView
     end
 
+    test "shows participation view after rejected contribution and member expiry", %{
+      assignment: assignment,
+      user: user
+    } do
+      assignment = Assignment.Factories.add_participant(assignment, user)
+      mark_intro_visited(assignment, user)
+      finish_all_tasks(assignment, user)
+
+      assignment
+      |> Assignment.Public.get_participation(user)
+      |> Ecto.Changeset.change(
+        rejected_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      )
+      |> Repo.update!()
+
+      Assignment.Public.expire_member(assignment, user)
+
+      %{view: view} = Assignment.CrewPageBuilder.view_model(assignment, build_assigns(user))
+
+      assert view.implementation == Assignment.ParticipationView
+    end
+
     test "shows finished view when consent declined", %{user: user} do
       assignment = Assignment.Factories.create_assignment_with_consent()
       assignment = Assignment.Factories.add_participant(assignment, user)


### PR DESCRIPTION
## Goal
[Flux issue 10249739541](https://app.basecamp.com/5734045/buckets/35926565/todos/10249739541)

Route a rejected participant from NBA and history links directly to the rejection outcome rather than a blank task page.

## Changes
- Include expired crew members while resolving the terminal participation route.
- Rename the exceptional crew lookup to `get_member_including_expired/3`.
- Cover the rejected-contribution and expired-member route.

## Verification
- `cd core && MIX_ENV=test mix compile --force`
- `cd core && mix test test/systems/assignment/crew_page_builder_test.exs` (15 tests)
