### PR TITLE
Add role-aware authentication entry routes

### DIFF
--- a/core/bundles/next/bundle.ex
+++ b/core/bundles/next/bundle.ex
@@ -10,8 +10,13 @@ defmodule Next.Bundle do
           pipe_through([:browser, :redirect_if_user_is_authenticated])
           live("/user/signin", Account.SigninPage)
           live("/user/signin/:user_type", Account.SigninPage)
-          live("/user/auth/identify", Account.AuthPage)
-          live("/user/auth/identify/:provider", Account.AuthSignupPage)
+          live("/user/auth/identify", Account.AuthIdentifyPage, :creator, as: :auth_identify)
+
+          live("/user/auth/identify/participant", Account.AuthIdentifyPage, :participant,
+            as: :auth_identify
+          )
+
+          live("/user/auth/identify/:provider", Account.AuthProviderPage)
           live("/user/auth/verify", Account.AuthCodeVerifyPage)
           get("/user/session", Account.SessionController, :new)
           post("/user/session", Account.SessionController, :create)
@@ -30,8 +35,8 @@ defmodule Next.Bundle do
     if include?() do
       quote do
         grant_access(Next.Account.SigninPage, [:visitor, :user])
-        grant_access(Next.Account.AuthSignupPage, [:visitor, :user])
-        grant_access(Next.Account.AuthPage, [:visitor, :user])
+        grant_access(Next.Account.AuthProviderPage, [:visitor, :user])
+        grant_access(Next.Account.AuthIdentifyPage, [:visitor, :user])
         grant_access(Next.Account.AuthCodeVerifyPage, [:visitor, :user])
       end
     end

--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -12,6 +12,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
   alias CoreWeb.Endpoint
   alias CoreWeb.ReturnTo
   alias Frameworks.Pixel.Button
+  alias Frameworks.Utility.Params
   alias Systems.Account
 
   @token_salt "otp-redeem"
@@ -27,6 +28,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
           email: email,
           form: to_form(%{"code" => ""}),
           error: nil,
+          creator?: Params.parse_creator(params),
           return_to: ReturnTo.sanitize(Map.get(params, "return_to"))
         )
         |> update_menus()
@@ -45,10 +47,17 @@ defmodule Next.Account.AuthCodeVerifyPage do
   def handle_event("verify", %{"code" => code}, %{assigns: %{email: email}} = socket) do
     code = String.trim(code)
     return_to = socket.assigns[:return_to]
+    creator? = socket.assigns.creator?
 
     case Account.Public.verify_otp(email, code) do
       {:ok, user} ->
-        payload = %{user_id: user && user.id, email: email, return_to: return_to}
+        payload = %{
+          user_id: user && user.id,
+          email: email,
+          creator?: creator?,
+          return_to: return_to
+        }
+
         token = Phoenix.Token.sign(Endpoint, @token_salt, payload)
         {:noreply, redirect(socket, to: ~p"/user/auth/redeem?token=#{token}")}
 

--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -44,10 +44,12 @@ defmodule Next.Account.AuthCodeVerifyPage do
   end
 
   @impl true
-  def handle_event("verify", %{"code" => code}, %{assigns: %{email: email}} = socket) do
+  def handle_event(
+        "verify",
+        %{"code" => code},
+        %{assigns: %{email: email, return_to: return_to, creator?: creator?}} = socket
+      ) do
     code = String.trim(code)
-    return_to = socket.assigns[:return_to]
-    creator? = socket.assigns.creator?
 
     case Account.Public.verify_otp(email, code) do
       {:ok, user} ->

--- a/core/bundles/next/lib/account/auth_identify_page.ex
+++ b/core/bundles/next/lib/account/auth_identify_page.ex
@@ -1,4 +1,4 @@
-defmodule Next.Account.AuthPage do
+defmodule Next.Account.AuthIdentifyPage do
   use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
@@ -16,6 +16,8 @@ defmodule Next.Account.AuthPage do
 
   @impl true
   def mount(params, _session, socket) do
+    creator? = socket.assigns.live_action != :participant
+
     if feature_enabled?(:otp) do
       {
         :ok,
@@ -24,6 +26,7 @@ defmodule Next.Account.AuthPage do
           form: to_form(%{"email" => ""}),
           error: nil,
           loading: false,
+          creator?: creator?,
           return_to: ReturnTo.sanitize(Map.get(params, "return_to"))
         )
         |> update_menus()
@@ -66,6 +69,7 @@ defmodule Next.Account.AuthPage do
   @impl true
   def handle_info({:route_email, email}, socket) do
     return_to = socket.assigns[:return_to]
+    creator? = socket.assigns.creator?
 
     case Account.EmailRouter.route(email) do
       :google ->
@@ -75,12 +79,15 @@ defmodule Next.Account.AuthPage do
         {:noreply, redirect(socket, to: ReturnTo.append("/auth/surfconext", return_to))}
 
       :mock ->
-        {:noreply, redirect(socket, to: "/auth/mock/callback?email=#{URI.encode(email)}")}
+        {:noreply,
+         redirect(socket,
+           to: "/auth/mock/callback?email=#{URI.encode(email)}"
+         )}
 
       :otp ->
         case Account.Public.generate_otp(email) do
           :ok ->
-            {:noreply, push_navigate(socket, to: verify_url(email, return_to))}
+            {:noreply, push_navigate(socket, to: verify_url(email, return_to, creator?))}
 
           {:error, :rate_limited} ->
             {:noreply,
@@ -94,10 +101,11 @@ defmodule Next.Account.AuthPage do
 
   defp google_url(email), do: "/auth/google?login_hint=#{URI.encode_www_form(email)}"
 
-  defp verify_url(email, nil), do: ~p"/user/auth/verify?email=#{email}"
+  defp verify_url(email, nil, creator?),
+    do: ~p"/user/auth/verify?email=#{email}&creator=#{creator?}"
 
-  defp verify_url(email, return_to),
-    do: ~p"/user/auth/verify?email=#{email}&return_to=#{return_to}"
+  defp verify_url(email, return_to, creator?),
+    do: ~p"/user/auth/verify?email=#{email}&return_to=#{return_to}&creator=#{creator?}"
 
   defp valid_email?(email), do: String.match?(email, ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/)
 

--- a/core/bundles/next/lib/account/auth_identify_page.ex
+++ b/core/bundles/next/lib/account/auth_identify_page.ex
@@ -67,10 +67,10 @@ defmodule Next.Account.AuthIdentifyPage do
   end
 
   @impl true
-  def handle_info({:route_email, email}, socket) do
-    return_to = socket.assigns[:return_to]
-    creator? = socket.assigns.creator?
-
+  def handle_info(
+        {:route_email, email},
+        %{assigns: %{return_to: return_to, creator?: creator?}} = socket
+      ) do
     case Account.EmailRouter.route(email) do
       :google ->
         {:noreply, redirect(socket, to: ReturnTo.append(google_url(email), return_to))}

--- a/core/bundles/next/lib/account/auth_provider_page.ex
+++ b/core/bundles/next/lib/account/auth_provider_page.ex
@@ -1,4 +1,4 @@
-defmodule Next.Account.AuthSignupPage do
+defmodule Next.Account.AuthProviderPage do
   use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})

--- a/core/bundles/next/lib/account/session_controller.ex
+++ b/core/bundles/next/lib/account/session_controller.ex
@@ -101,7 +101,7 @@ defmodule Next.Account.SessionController do
     do: register_new_email_user(conn, email, payload)
 
   defp register_new_email_user(conn, email, payload) do
-    case Account.Public.register_user_with_email(email) do
+    case Account.Public.register_user_with_email(email, Map.get(payload, :creator?, false)) do
       {:ok, user} ->
         conn
         |> stash_return_to(payload)

--- a/core/frameworks/utility/params.ex
+++ b/core/frameworks/utility/params.ex
@@ -22,6 +22,8 @@ defmodule Frameworks.Utility.Params do
   end
 
   @doc "Get a trimmed string param when present; returns nil for missing/blank."
+  def parse_creator(params), do: parse_bool_param(params, "creator", true)
+
   def parse_string_param(params, key) when is_map(params) do
     case Map.get(params, key) do
       nil ->
@@ -35,6 +37,4 @@ defmodule Frameworks.Utility.Params do
         nil
     end
   end
-
-  def parse_creator(params), do: parse_bool_param(params, "creator")
 end

--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -305,11 +305,12 @@ defmodule Systems.Account.Public do
   the inbox). The account stays unconfirmed until the user accepts terms
   & privacy in the onboarding step.
   """
-  def register_user_with_email(email) when is_binary(email) do
+  def register_user_with_email(email, creator? \\ true)
+      when is_binary(email) and is_boolean(creator?) do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
     %User{}
-    |> User.sso_changeset(%{email: email, creator: false, verified_at: now})
+    |> User.sso_changeset(%{email: email, creator: creator?, verified_at: now})
     |> User.validate_email()
     |> Repo.insert()
   end

--- a/core/systems/account/auth/google/plug.ex
+++ b/core/systems/account/auth/google/plug.ex
@@ -91,7 +91,6 @@ defmodule Systems.Account.Auth.Google.CallbackPlug do
   end
 
   defp authenticate(conn, otp_app, session_params) do
-    creator? = Params.parse_creator(session_params)
     post_action = Params.parse_string_param(session_params, "post_signin_action")
 
     config = config(otp_app) |> Keyword.put(:session_params, session_params)
@@ -105,9 +104,7 @@ defmodule Systems.Account.Auth.Google.CallbackPlug do
     case Systems.Account.Auth.authenticate_or_transfer(
            Systems.Account.Auth.Google,
            google_user,
-           %{
-             creator: creator?
-           }
+           %{creator: true}
          ) do
       {:transfer, user} ->
         conn

--- a/core/systems/account/auth/mock.ex
+++ b/core/systems/account/auth/mock.ex
@@ -61,9 +61,11 @@ defmodule Systems.Account.Auth.Mock.CallbackController do
       case Repo.get_by(User, email: email) do
         nil ->
           {:ok, %{user: user}} =
-            Systems.Account.Auth.authenticate(Systems.Account.Auth.Mock, %{
-              "email" => email
-            })
+            Systems.Account.Auth.authenticate(
+              Systems.Account.Auth.Mock,
+              %{"email" => email},
+              %{creator: true}
+            )
 
           conn
           |> Systems.Account.UserAuth.sign_out_current_user()

--- a/core/test/bundles/next/account/auth_identify_page_test.exs
+++ b/core/test/bundles/next/account/auth_identify_page_test.exs
@@ -1,0 +1,25 @@
+defmodule Next.Account.AuthIdentifyPageTest do
+  use CoreWeb.ConnCase, async: false
+  use Core.FeatureFlags.Test
+
+  import Phoenix.LiveViewTest
+
+  test "participant entry uses the shared identify page", %{conn: conn} do
+    set_feature_flag(:otp, true)
+
+    {:ok, _view, html} = live(conn, "/user/auth/identify/participant")
+
+    assert html =~ "auth-email-input"
+    refute html =~ "auth-signin-button"
+  end
+
+  test "participant entry carries its role into OTP verification", %{conn: conn} do
+    set_feature_flag(:otp, true)
+    email = "participant-#{System.unique_integer([:positive])}@example.invalid"
+
+    {:ok, view, _html} = live(conn, "/user/auth/identify/participant")
+    render_submit(view, "submit", %{"email" => email})
+
+    assert_redirect(view, "/user/auth/verify?email=#{URI.encode_www_form(email)}&creator=false")
+  end
+end

--- a/core/test/bundles/next/account/auth_provider_page_test.exs
+++ b/core/test/bundles/next/account/auth_provider_page_test.exs
@@ -1,4 +1,4 @@
-defmodule Next.Account.AuthSignupPageTest do
+defmodule Next.Account.AuthProviderPageTest do
   use CoreWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 

--- a/core/test/bundles/next/account/session_controller_test.exs
+++ b/core/test/bundles/next/account/session_controller_test.exs
@@ -29,6 +29,25 @@ defmodule Next.Account.SessionControllerTest do
       conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
 
       assert redirected_to(conn) == "/user/onboarding"
+      refute Systems.Account.Public.get_user_by_email(email).creator
+    end
+  end
+
+  describe "GET /user/auth/redeem — participant entry" do
+    test "creates a participant account", %{conn: conn} do
+      email = "participant-#{Faker.UUID.v4()}@example.com"
+
+      token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: email,
+          creator?: false,
+          return_to: nil
+        })
+
+      _conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
+
+      refute Systems.Account.Public.get_user_by_email(email).creator
     end
   end
 
@@ -73,6 +92,24 @@ defmodule Next.Account.SessionControllerTest do
       conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
 
       assert redirected_to(conn) == "/pool/panl/join"
+    end
+  end
+
+  describe "GET /user/auth/redeem — existing creator via participant entry" do
+    test "retains the stored account type", %{conn: conn} do
+      user = Factories.insert!(:member, %{creator: true})
+
+      token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: user.id,
+          email: user.email,
+          creator?: false,
+          return_to: nil
+        })
+
+      _conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
+
+      assert Systems.Account.Public.get_user!(user.id).creator
     end
   end
 

--- a/core/test/systems/account/_public_test.exs
+++ b/core/test/systems/account/_public_test.exs
@@ -128,6 +128,13 @@ defmodule Systems.Account.PublicTest do
       assert user.email == email
       assert user.hashed_password == "no-password-set"
       assert Account.Public.passwordless?(user)
+      assert user.creator
+    end
+
+    test "creates a participant when requested" do
+      {:ok, user} = Account.Public.register_user_with_email(Faker.Internet.email(), false)
+
+      refute user.creator
     end
 
     test "does not set confirmed_at (terms acceptance will)" do


### PR DESCRIPTION
## Goal
[Flux issue 10255455078](https://app.basecamp.com/5734045/buckets/35926565/todos/10255455078)

Provide creator-default and participant authentication entry routes while retaining existing users' stored account type.

## Changes
- Add `/user/auth/identify/participant` beside the creator-default identify route, before the provider route.
- Rename the identify and provider pages to reflect their responsibilities.
- Carry the role hint through OTP verification and redemption only for new account creation.
- Make new OTP and IdP accounts creator-default; participant entry explicitly creates a participant through OTP.
- Preserve pre-deploy OTP tokens without a role hint as participant registrations.

## Compatibility
- MX/UserCheck-based routing for unknown emails is unchanged here. [Follow-up issue 10256049943](https://app.basecamp.com/5734045/buckets/35926565/todos/10256049943) will make unknown-email authentication OTP-only.

## Verification
- `cd core && mix test test/systems/account/auth/google/plug_test.exs test/systems/account/auth/surfconext/plug_test.exs test/systems/account/auth/mock_test.exs test/bundles/next/account/auth_identify_page_test.exs test/bundles/next/account/auth_provider_page_test.exs test/bundles/next/account/auth_code_verify_page_test.exs test/bundles/next/account/session_controller_test.exs test/systems/account/_public_test.exs` (120 tests)
- `cd core && mix compile --force`
- Commit hooks: `mix format`, `mix compile`, and `mix credo`
