### PR TITLE
Route unknown authentication emails through OTP

### DIFF
--- a/core/systems/account/email_router.ex
+++ b/core/systems/account/email_router.ex
@@ -12,20 +12,10 @@ defmodule Systems.Account.EmailRouter do
     end
   end
 
-  defp route_unknown_email(email), do: organization_idp(email) || user_check_idp(email)
+  defp route_unknown_email(email), do: organization_idp(email) || :otp
 
   # ponytail: returns nil until Next Org domains gain an IdP property.
   defp organization_idp(_email), do: nil
-
-  defp user_check_idp(email) do
-    case Frameworks.UserCheck.check_email(email) do
-      {:ok, result} ->
-        Methods.provider_for_mx_provider(result.mx_provider) || :otp
-
-      {:error, _reason} ->
-        :otp
-    end
-  end
 
   defp identity_provider(user) do
     Methods.satellite_providers()

--- a/core/test/systems/account/email_router_test.exs
+++ b/core/test/systems/account/email_router_test.exs
@@ -56,11 +56,11 @@ defmodule Systems.Account.EmailRouterTest do
     assert EmailRouter.route(user.email) == :otp
   end
 
-  test "routes an unknown email to its supported UserCheck MX provider" do
-    assert EmailRouter.route("google@custom-domain.test") == :google
+  test "routes an unknown Google-hosted email to OTP" do
+    assert EmailRouter.route("google@custom-domain.test") == :otp
   end
 
-  test "falls back to OTP when UserCheck has no supported provider" do
+  test "routes unknown emails to OTP" do
     assert EmailRouter.route("unknown-#{System.unique_integer([:positive])}@custom-domain.test") ==
              :otp
   end


### PR DESCRIPTION
## Goal
[Flux issue 10256049943](https://app.basecamp.com/5734045/buckets/35926565/todos/10256049943)

Route unknown authentication emails through OTP while retaining the internal Org → IdP hook and known-account provider routing.

## Changes
- Remove UserCheck/MX-based IdP selection for unknown email addresses.
- Keep the existing Org-routing extension point; it falls back to OTP when no Org IdP applies.
- Cover an unknown Google-hosted address routing to OTP.

## Verification
- `cd core && mix test test/systems/account/email_router_test.exs test/systems/account/auth/methods_test.exs` (9 tests)
- Commit hooks: `mix format`, `mix compile`, and `mix credo`
