### PR TITLE
Add Centerdata OIDC sign-in

### DIFF
--- a/core/bundles/next/config/config.exs
+++ b/core/bundles/next/config/config.exs
@@ -16,6 +16,7 @@ config :core, Systems.Account.UserAuth,
 # unlisted flags keep their default from this config.
 config :core, :features,
   surfconext_sign_in: false,
+  centerdata_sign_in: false,
   member_google_sign_in: true,
   password_sign_in: true,
   debug_expire_force: false,
@@ -34,6 +35,7 @@ config :core, :meta,
 config :core, :account,
   auth_methods: %{
     surfconext: %{provider: true, satellite: true},
+    centerdata: %{provider: true, satellite: true},
     google: %{provider: true, satellite: true, mx_provider: "google"},
     email: %{provider: false, satellite: true}
   }

--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -192,6 +192,14 @@ config :core, Systems.Account.Auth.Surfconext,
   base_url: "https://connect.test.surfconext.nl",
   redirect_uri: "not-set"
 
+config :core, Systems.Account.Auth.Centerdata,
+  client_id: "not-set",
+  client_secret: "not-set",
+  base_url: "https://messpanel.test.centerdata.nl",
+  openid_configuration_uri: "https://messpanel.test.centerdata.nl/openid_configuration/",
+  redirect_uri: "not-set",
+  authorization_params: [scope: "email"]
+
 # Domains routed to Surfconext SSO on the email-first auth page.
 # Override in runtime config per environment.
 config :core, :surfconext_domains, []

--- a/core/config/dev.exs
+++ b/core/config/dev.exs
@@ -137,6 +137,7 @@ config :core,
 config :core, :account,
   auth_methods: %{
     surfconext: %{provider: true, satellite: true},
+    centerdata: %{provider: true, satellite: true},
     google: %{provider: true, satellite: true, mx_provider: "google"},
     apple: %{provider: true, satellite: true},
     email: %{provider: false, satellite: true},

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -197,6 +197,18 @@ if config_env() == :prod do
     client_id: System.get_env("SURFCONEXT_CLIENT_ID"),
     client_secret: System.get_env("SURFCONEXT_CLIENT_SECRET")
 
+  config :core, Systems.Account.Auth.Centerdata,
+    redirect_uri: "#{base_url}/auth/centerdata/callback",
+    base_url: System.get_env("CENTERDATA_SITE", "https://messpanel.test.centerdata.nl"),
+    openid_configuration_uri:
+      System.get_env(
+        "CENTERDATA_OPENID_CONFIGURATION_URI",
+        "https://messpanel.test.centerdata.nl/openid_configuration/"
+      ),
+    client_id: System.get_env("CENTERDATA_CLIENT_ID"),
+    client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
+    authorization_params: [scope: "email"]
+
   config :core, Core.ImageCatalog.Unsplash,
     access_key: System.get_env("UNSPLASH_ACCESS_KEY"),
     app_name: System.get_env("UNSPLASH_APP_NAME")

--- a/core/config/runtime.fly.exs
+++ b/core/config/runtime.fly.exs
@@ -177,6 +177,18 @@ if config_env() == :prod do
     client_id: System.get_env("SURFCONEXT_CLIENT_ID"),
     client_secret: System.get_env("SURFCONEXT_CLIENT_SECRET")
 
+  config :core, Systems.Account.Auth.Centerdata,
+    redirect_uri: "#{base_url}/auth/centerdata/callback",
+    base_url: System.get_env("CENTERDATA_SITE", "https://messpanel.test.centerdata.nl"),
+    openid_configuration_uri:
+      System.get_env(
+        "CENTERDATA_OPENID_CONFIGURATION_URI",
+        "https://messpanel.test.centerdata.nl/openid_configuration/"
+      ),
+    client_id: System.get_env("CENTERDATA_CLIENT_ID"),
+    client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
+    authorization_params: [scope: "email"]
+
   config :core, Core.ImageCatalog.Unsplash,
     access_key: System.get_env("UNSPLASH_ACCESS_KEY"),
     app_name: System.get_env("UNSPLASH_APP_NAME")

--- a/core/config/test.exs
+++ b/core/config/test.exs
@@ -114,6 +114,7 @@ config :wallaby,
 
 config :core, :features,
   member_google_sign_in: true,
+  centerdata_sign_in: true,
   password_sign_in: true,
   debug_expire_force: true,
   panl: true,
@@ -128,6 +129,9 @@ config :core, Oban, queues: false, plugins: false
 
 config :core, Systems.Account.Auth.Surfconext,
   oidc_module: Systems.Account.Auth.Surfconext.FakeOIDC
+
+config :core, Systems.Account.Auth.Centerdata,
+  oidc_module: Systems.Account.Auth.Centerdata.FakeOIDC
 
 # Tests always use the next bundle
 config :core, :bundle, :next

--- a/core/lib/core_web/router.ex
+++ b/core/lib/core_web/router.ex
@@ -3,6 +3,7 @@ defmodule CoreWeb.Router do
 
   require Core.BundleOverrides
   require Systems.Account.Auth.Surfconext
+  require Systems.Account.Auth.Centerdata
   require CoreWeb.Routes
   require CoreWeb.LocalImageCatalogPlug
   require Frameworks.E2E.Routes
@@ -13,6 +14,7 @@ defmodule CoreWeb.Router do
   Systems.Account.Auth.Google.routes(:core)
 
   Systems.Account.Auth.Surfconext.routes(:core)
+  Systems.Account.Auth.Centerdata.routes(:core)
 
   CoreWeb.Routes.routes()
   CoreWeb.LocalImageCatalogPlug.routes()

--- a/core/priv/repo/migrations/20260901173719_create_centerdata_user.exs
+++ b/core/priv/repo/migrations/20260901173719_create_centerdata_user.exs
@@ -1,0 +1,15 @@
+defmodule Core.Repo.Migrations.CreateCenterdataUser do
+  use Ecto.Migration
+
+  def change do
+    create table(:centerdata_user) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:sub, :string, null: false)
+      add(:email, :string, null: false)
+      add(:userinfo, :map, default: %{}, null: false)
+      timestamps()
+    end
+
+    create(unique_index(:centerdata_user, :sub))
+  end
+end

--- a/core/systems/account/auth/centerdata.ex
+++ b/core/systems/account/auth/centerdata.ex
@@ -1,0 +1,59 @@
+defmodule Systems.Account.Auth.Centerdata do
+  @moduledoc "Centerdata/LISS Panel identity provider."
+  @behaviour Systems.Account.Auth.Provider
+
+  alias Core.Repo
+  alias Systems.Account.Auth.Centerdata.UserModel
+  alias Systems.Account.User
+
+  defmodule CenterdataError do
+    defexception [:message]
+  end
+
+  @impl Systems.Account.Auth.Provider
+  def user_attrs(%{"email" => email, "email_verified" => true}) when is_binary(email) do
+    %{email: email, confirmed_at: NaiveDateTime.utc_now()}
+  end
+
+  def user_attrs(userinfo) do
+    raise CenterdataError, "Centerdata did not provide a verified email: #{inspect(userinfo)}"
+  end
+
+  @impl Systems.Account.Auth.Provider
+  def get(%User{id: id}), do: Repo.get_by(UserModel, user_id: id)
+
+  @impl Systems.Account.Auth.Provider
+  def attach(%User{} = user, userinfo) do
+    %UserModel{}
+    |> UserModel.changeset(userinfo)
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> Repo.insert()
+  end
+
+  @impl Systems.Account.Auth.Provider
+  def refresh(%User{} = user, userinfo) do
+    user
+    |> get()
+    |> UserModel.changeset(userinfo)
+    |> Repo.update!()
+  end
+
+  defmacro routes(otp_app) do
+    quote bind_quoted: [otp_app: otp_app] do
+      pipeline :centerdata_browser do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+
+      scope "/", Systems.Account.Auth.Centerdata do
+        pipe_through([:centerdata_browser])
+        get("/auth/centerdata", AuthorizePlug, otp_app)
+      end
+
+      scope "/", Systems.Account.Auth.Centerdata do
+        pipe_through([:browser])
+        get("/auth/centerdata/callback", CallbackController, :authenticate)
+      end
+    end
+  end
+end

--- a/core/systems/account/auth/centerdata/plug.ex
+++ b/core/systems/account/auth/centerdata/plug.ex
@@ -1,0 +1,111 @@
+defmodule Systems.Account.Auth.Centerdata.PlugUtils do
+  alias Systems.Account.Auth
+
+  def config(otp_app), do: Application.fetch_env!(otp_app, Auth.Centerdata)
+  def oidc_module(config), do: Keyword.get(config, :oidc_module, Assent.Strategy.OIDC)
+
+  def log_in_user(config, conn, user, first_time?),
+    do:
+      Keyword.get(config, :log_in_user, &Systems.Account.UserAuth.log_in_user/3).(
+        conn,
+        user,
+        first_time?
+      )
+end
+
+defmodule Systems.Account.Auth.Centerdata.AuthorizePlug do
+  import Plug.Conn
+  import Systems.Account.Auth.Centerdata.PlugUtils
+  use Core.FeatureFlags
+
+  def init(otp_app) when is_atom(otp_app), do: otp_app
+
+  def call(conn, otp_app) do
+    if feature_enabled?(:centerdata_sign_in) do
+      config = config(otp_app) |> Keyword.put(:nonce, nonce())
+
+      {:ok, %{url: url, session_params: session_params}} =
+        oidc_module(config).authorize_url(config)
+
+      conn
+      |> put_session(:centerdata, session_params)
+      |> Phoenix.Controller.redirect(external: url)
+    else
+      conn |> send_resp(404, "Not found") |> halt()
+    end
+  end
+
+  defp nonce do
+    16
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+end
+
+defmodule Systems.Account.Auth.Centerdata.CallbackController do
+  require Logger
+  use Phoenix.Controller, formats: [:html]
+  use CoreWeb, :verified_routes
+
+  import Plug.Conn
+  import Systems.Account.Auth.Centerdata.PlugUtils
+  use Core.FeatureFlags
+
+  alias Systems.Account.Auth
+
+  def authenticate(conn, params) do
+    if feature_enabled?(:centerdata_sign_in) do
+      case get_session(conn, :centerdata) do
+        nil -> redirect_with_error(conn, "session_not_found")
+        session_params -> authenticate(conn, params, session_params)
+      end
+    else
+      conn |> send_resp(404, "Not found") |> halt()
+    end
+  end
+
+  defp authenticate(conn, params, session_params) do
+    config =
+      config(:core)
+      |> Keyword.put(:session_params, session_params)
+      |> Keyword.put(:nonce, session_params.nonce)
+
+    with {:ok, %{user: userinfo}} <- oidc_module(config).callback(config, params),
+         :ok <- validate_userinfo(userinfo) do
+      case Auth.authenticate_or_transfer(Auth.Centerdata, userinfo) do
+        {:transfer, user} ->
+          conn
+          |> Systems.Account.UserAuth.sign_out_current_user()
+          |> put_session(:idp_transfer, %{
+            "email" => user.email,
+            "idp" => "centerdata",
+            "user_id" => user.id,
+            "userinfo" => userinfo
+          })
+          |> redirect(to: ~p"/auth/centerdata/transfer")
+
+        {:ok, %{user: user, first_time?: first_time?}} ->
+          log_in_user(config, conn, user, first_time?)
+
+        {:error, changeset} ->
+          Auth.SSOHelpers.handle_registration_error(conn, changeset)
+      end
+    else
+      reason ->
+        Logger.warning("[Centerdata] rejected OIDC callback: #{inspect(reason)}")
+        redirect_with_error(conn, "invalid_identity")
+    end
+  end
+
+  defp validate_userinfo(%{"sub" => sub, "email" => email, "email_verified" => true})
+       when is_binary(sub) and is_binary(email),
+       do: :ok
+
+  defp validate_userinfo(_userinfo), do: {:error, :missing_verified_identity}
+
+  defp redirect_with_error(conn, error) do
+    conn
+    |> put_flash(:error, Auth.SSOHelpers.error_message(error))
+    |> redirect(to: ~p"/user/signin")
+  end
+end

--- a/core/systems/account/auth/centerdata/user_model.ex
+++ b/core/systems/account/auth/centerdata/user_model.ex
@@ -1,0 +1,22 @@
+defmodule Systems.Account.Auth.Centerdata.UserModel do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "centerdata_user" do
+    belongs_to(:user, Systems.Account.User)
+    field(:email, :string)
+    field(:sub, :string)
+    field(:userinfo, :map, default: %{})
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = identity, userinfo) do
+    identity
+    |> cast(%{email: userinfo["email"], sub: userinfo["sub"], userinfo: userinfo}, [
+      :email,
+      :sub,
+      :userinfo
+    ])
+    |> validate_required([:email, :sub])
+  end
+end

--- a/core/systems/account/auth/identity_provider_transfer_controller.ex
+++ b/core/systems/account/auth/identity_provider_transfer_controller.ex
@@ -29,6 +29,7 @@ defmodule Systems.Account.Auth.IdentityProviderTransferController do
 
   @providers %{
     "apple" => {Auth.Apple, :apple},
+    "centerdata" => {Auth.Centerdata, :centerdata},
     "google" => {Auth.Google, :google},
     "surfconext" => {Auth.Surfconext, :surfconext}
   }

--- a/core/systems/account/auth/identity_provider_transfer_page.ex
+++ b/core/systems/account/auth/identity_provider_transfer_page.ex
@@ -25,6 +25,7 @@ defmodule Systems.Account.Auth.IdentityProviderTransferPage do
     {:ok, Phoenix.LiveView.redirect(socket, to: ~p"/user/auth/identify")}
   end
 
+  defp idp_label("centerdata"), do: "Centerdata"
   defp idp_label("surfconext"), do: "SURFconext"
   defp idp_label(idp), do: String.capitalize(idp)
 

--- a/core/test/systems/account/auth/centerdata/plug_test.exs
+++ b/core/test/systems/account/auth/centerdata/plug_test.exs
@@ -1,0 +1,82 @@
+defmodule Systems.Account.Auth.Centerdata.FakeOIDC do
+  def authorize_url(config),
+    do:
+      {:ok,
+       %{url: config[:base_url], session_params: %{state: "test-state", nonce: config[:nonce]}}}
+
+  def callback(config, _params), do: {:ok, %{user: config[:userinfo]}}
+end
+
+defmodule Systems.Account.Auth.Centerdata.PlugTest do
+  use CoreWeb.ConnCase, async: false
+
+  alias Systems.Account.Auth.Centerdata.AuthorizePlug
+
+  setup do
+    original = Application.get_env(:core, Systems.Account.Auth.Centerdata, [])
+
+    config = [
+      client_id: "test-client",
+      client_secret: "test-secret",
+      base_url: "https://messpanel.test.centerdata.nl",
+      redirect_uri: "http://localhost/auth/centerdata/callback",
+      oidc_module: Systems.Account.Auth.Centerdata.FakeOIDC,
+      userinfo: %{"sub" => "-1", "email" => "panel@example.com", "email_verified" => true}
+    ]
+
+    Application.put_env(:core, Systems.Account.Auth.Centerdata, config)
+    on_exit(fn -> Application.put_env(:core, Systems.Account.Auth.Centerdata, original) end)
+    {:ok, config: config}
+  end
+
+  test "starts a Centerdata OIDC sign-in", %{config: config} do
+    conn =
+      Plug.Test.conn(:get, "/auth/centerdata")
+      |> init_test_session(%{})
+      |> AuthorizePlug.call(:core)
+
+    assert %{state: "test-state", nonce: nonce} = conn.private.plug_session["centerdata"]
+    assert is_binary(nonce)
+    assert redirected_to(conn) == config[:base_url]
+  end
+
+  test "is unavailable when the feature is disabled", %{conn: conn} do
+    features = Application.fetch_env!(:core, :features)
+    Application.put_env(:core, :features, Keyword.put(features, :centerdata_sign_in, false))
+    on_exit(fn -> Application.put_env(:core, :features, features) end)
+
+    conn = get(conn, "/auth/centerdata")
+
+    assert conn.status == 404
+  end
+
+  test "creates an account from verified ID token claims", %{conn: conn} do
+    conn =
+      conn
+      |> init_test_session(%{centerdata: %{state: "test-state", nonce: "test-nonce"}})
+      |> get("/auth/centerdata/callback?code=test&state=test-state")
+
+    assert redirected_to(conn) == "/user/onboarding"
+    assert Systems.Account.Public.get_user_by_email("panel@example.com")
+  end
+
+  test "rejects an unverified ID token email", %{conn: conn, config: config} do
+    Application.put_env(
+      :core,
+      Systems.Account.Auth.Centerdata,
+      Keyword.put(config, :userinfo, %{
+        "sub" => "-1",
+        "email" => "panel@example.com",
+        "email_verified" => false
+      })
+    )
+
+    conn =
+      conn
+      |> init_test_session(%{centerdata: %{state: "test-state", nonce: "test-nonce"}})
+      |> get("/auth/centerdata/callback?code=test&state=test-state")
+
+    assert redirected_to(conn) == "/user/signin"
+    refute Systems.Account.Public.get_user_by_email("panel@example.com")
+  end
+end

--- a/core/test/systems/account/auth/centerdata_test.exs
+++ b/core/test/systems/account/auth/centerdata_test.exs
@@ -1,0 +1,39 @@
+defmodule Systems.Account.Auth.CenterdataTest do
+  use Core.DataCase, async: true
+
+  alias Core.Factories
+  alias Systems.Account.Auth.Centerdata
+
+  test "uses a verified email for the account" do
+    attrs =
+      Centerdata.user_attrs(%{
+        "sub" => "123",
+        "email" => "panel@example.com",
+        "email_verified" => true
+      })
+
+    assert attrs.email == "panel@example.com"
+    assert %NaiveDateTime{} = attrs.confirmed_at
+  end
+
+  test "rejects an unverified email" do
+    assert_raise Centerdata.CenterdataError, fn ->
+      Centerdata.user_attrs(%{
+        "sub" => "123",
+        "email" => "panel@example.com",
+        "email_verified" => false
+      })
+    end
+  end
+
+  test "attaches the permanent Centerdata subject" do
+    user = Factories.insert!(:member, %{email: "panel@example.com"})
+    userinfo = %{"sub" => "123", "email" => user.email, "email_verified" => true}
+
+    {:ok, identity} = Centerdata.attach(user, userinfo)
+
+    assert identity.user_id == user.id
+    assert identity.sub == "123"
+    assert identity.userinfo == userinfo
+  end
+end

--- a/core/test/systems/account/auth/identity_provider_transfer_page_test.exs
+++ b/core/test/systems/account/auth/identity_provider_transfer_page_test.exs
@@ -4,7 +4,7 @@ defmodule Systems.Account.Auth.IdentityProviderTransferPageTest do
   import Phoenix.LiveViewTest
 
   alias Core.{Factories, Repo}
-  alias Systems.Account.Auth.{Email, Google, Surfconext}
+  alias Systems.Account.Auth.{Centerdata, Email, Google, Surfconext}
 
   test "renders the transfer details from the pending transition", %{conn: conn} do
     conn =
@@ -24,6 +24,12 @@ defmodule Systems.Account.Auth.IdentityProviderTransferPageTest do
   end
 
   for {idp, provider, userinfo} <- [
+        {"centerdata", Centerdata,
+         %{
+           "email" => "centerdata-transfer@example.com",
+           "email_verified" => true,
+           "sub" => "centerdata-transfer-sub"
+         }},
         {"google", Google, %{"sub" => "google-transfer-sub"}},
         {"surfconext", Surfconext,
          %{"email" => "surfconext-transfer@example.com", "sub" => "surfconext-transfer-sub"}}

--- a/core/test/systems/account/auth/methods_test.exs
+++ b/core/test/systems/account/auth/methods_test.exs
@@ -11,6 +11,7 @@ defmodule Systems.Account.Auth.MethodsTest do
       :account,
       Keyword.put(account, :auth_methods, %{
         surfconext: %{provider: true, satellite: true},
+        centerdata: %{provider: true, satellite: true},
         google: %{provider: true, satellite: true, mx_provider: "google"},
         email: %{provider: false, satellite: true},
         mock: %{provider: true, satellite: false}
@@ -24,14 +25,15 @@ defmodule Systems.Account.Auth.MethodsTest do
   test "derives satellite modules" do
     assert Methods.satellites() == %{
              surfconext: Systems.Account.Auth.Surfconext.UserModel,
+             centerdata: Systems.Account.Auth.Centerdata.UserModel,
              google: Systems.Account.Auth.Google.UserModel,
              email: Systems.Account.Auth.Email.UserModel
            }
   end
 
   test "returns providers and satellite-backed providers" do
-    assert Enum.sort(Methods.providers()) == [:google, :mock, :surfconext]
-    assert Enum.sort(Methods.satellite_providers()) == [:google, :surfconext]
+    assert Enum.sort(Methods.providers()) == [:centerdata, :google, :mock, :surfconext]
+    assert Enum.sort(Methods.satellite_providers()) == [:centerdata, :google, :surfconext]
   end
 
   test "returns a satellite module" do


### PR DESCRIPTION
## Goal
[OAuth Centerdata / LISS panel](https://app.basecamp.com/5734045/buckets/45752250/messages/10218767963)

Enable a gated Centerdata/LISS Panel OIDC sign-in flow for development testing.

## Changes
- Add a Centerdata OIDC provider that validates ID Token claims, requiring `sub`, `email`, and `email_verified: true`.
- Persist Centerdata identities and support identity-transfer flows.
- Request the provider's `email` scope, use its temporary discovery URL, and generate a cryptographically random nonce for each sign-in.
- Gate the authorization and callback routes behind the false-by-default `centerdata_sign_in` feature flag.

## Verification
- `cd core && mix test test/systems/account/auth/centerdata_test.exs test/systems/account/auth/centerdata/plug_test.exs test/systems/account/auth/methods_test.exs test/systems/account/auth/identity_provider_transfer_page_test.exs` — 16 tests passed
- Pre-commit: `mix format`, `mix compile`, `mix credo`
- Pre-push: `mix test`, `mix dialyzer`
