### PR TITLE
Enable PKCE for Centerdata sign-in

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -198,7 +198,8 @@ config :core, Systems.Account.Auth.Centerdata,
   base_url: "https://messpanel.test.centerdata.nl",
   openid_configuration_uri: "https://messpanel.test.centerdata.nl/openid_configuration/",
   redirect_uri: "not-set",
-  authorization_params: [scope: "email"]
+  authorization_params: [scope: "email"],
+  code_verifier: true
 
 # Domains routed to Surfconext SSO on the email-first auth page.
 # Override in runtime config per environment.

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -207,7 +207,8 @@ if config_env() == :prod do
       ),
     client_id: System.get_env("CENTERDATA_CLIENT_ID"),
     client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
-    authorization_params: [scope: "email"]
+    authorization_params: [scope: "email"],
+    code_verifier: true
 
   config :core, Core.ImageCatalog.Unsplash,
     access_key: System.get_env("UNSPLASH_ACCESS_KEY"),

--- a/core/config/runtime.fly.exs
+++ b/core/config/runtime.fly.exs
@@ -187,7 +187,8 @@ if config_env() == :prod do
       ),
     client_id: System.get_env("CENTERDATA_CLIENT_ID"),
     client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
-    authorization_params: [scope: "email"]
+    authorization_params: [scope: "email"],
+    code_verifier: true
 
   config :core, Core.ImageCatalog.Unsplash,
     access_key: System.get_env("UNSPLASH_ACCESS_KEY"),


### PR DESCRIPTION
## Goal
[OAuth Centerdata / LISS panel](https://app.basecamp.com/5734045/buckets/45752250/messages/10218767963)

Send the PKCE challenge required by Centerdata's authorization server.

## Changes
- Enable Assent's PKCE code-verifier flow for Centerdata in default, Fly, and AWS runtime configuration.

## Verification
- `cd core && mix test test/systems/account/auth/centerdata/plug_test.exs` — 4 tests passed
- Verified Assent emits an `S256` `code_challenge` and retains the `code_verifier` in the session.
- Pre-commit: `mix format`, `mix credo`
- Pre-push: `mix test`, `mix dialyzer`
