### PR TITLE
Use POST client authentication for Centerdata

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -199,6 +199,7 @@ config :core, Systems.Account.Auth.Centerdata,
   openid_configuration_uri: "https://messpanel.test.centerdata.nl/openid_configuration/",
   redirect_uri: "not-set",
   authorization_params: [scope: "email"],
+  client_authentication_method: "client_secret_post",
   code_verifier: true
 
 # Domains routed to Surfconext SSO on the email-first auth page.

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -208,6 +208,7 @@ if config_env() == :prod do
     client_id: System.get_env("CENTERDATA_CLIENT_ID"),
     client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
     authorization_params: [scope: "email"],
+    client_authentication_method: "client_secret_post",
     code_verifier: true
 
   config :core, Core.ImageCatalog.Unsplash,

--- a/core/config/runtime.fly.exs
+++ b/core/config/runtime.fly.exs
@@ -188,6 +188,7 @@ if config_env() == :prod do
     client_id: System.get_env("CENTERDATA_CLIENT_ID"),
     client_secret: System.get_env("CENTERDATA_CLIENT_SECRET"),
     authorization_params: [scope: "email"],
+    client_authentication_method: "client_secret_post",
     code_verifier: true
 
   config :core, Core.ImageCatalog.Unsplash,


### PR DESCRIPTION
## Goal
[OAuth Centerdata / LISS panel](https://app.basecamp.com/5734045/buckets/45752250/messages/10218767963)

Use the token authentication method Centerdata requires.

## Changes
- Configure Centerdata's OIDC client to send its client ID and secret in the token POST.

## Verification
- `cd core && mix test test/systems/account/auth/centerdata/plug_test.exs` — 4 tests passed
