### PR TITLE
Fix banking proxy documentation build

### DIFF
--- a/banking_proxy/mix.exs
+++ b/banking_proxy/mix.exs
@@ -11,7 +11,7 @@ defmodule BankingProxy.MixProject do
       escript: escript(),
       docs: [
         main: "readme",
-        logo: "../core/priv/static/images/icons/next.svg",
+        logo: "../core/priv/static/images/logos/products/next.svg",
         extras: [
           "README.md"
         ]


### PR DESCRIPTION
## Goal
Restore the Docs workflow after the Next logo moved.

## Changes
- Point the banking-proxy ExDoc logo at the existing product-logo path.

## Verification
- `make docs`
- Pre-commit: `mix format`, `mix credo`
- Pre-push: `mix test`, `mix dialyzer`